### PR TITLE
SSL support added

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,20 +37,21 @@ $conf = YAML.load_file("conf/defaults.yml")
 
 # Overrides with user-defined options
 if File.file?("conf/conf.yml")
-  YAML.load_file("conf/conf.yml").each do |override|
+  $user_conf = YAML.load_file("conf/conf.yml")
+  $user_conf.each do |override|
     $conf[override[0]] = override[1]
   end
 end
 
 # Easy to use development version
 if $conf["development_setup"]
-  $conf["disable_ssl"] = true
-  $conf["servername_web"] = "localhost"
-  $conf["servername_api"] = "localhost"
-  $conf["port_web"] = 8081
-  $conf["port_api"] = 8083
-  $conf["prefer_local"] = true
-  $conf["expose_db"] = true
+  $conf["disable_ssl"] = true unless $user_conf.key?("disable_ssl")
+  $conf["servername_web"] = "localhost" unless $user_conf.key?("servername_web")
+  $conf["servername_api"] = "localhost" unless $user_conf.key?("servername_api")
+  $conf["port_web"] = 8081 unless $user_conf.key?("port_web")
+  $conf["port_api"] = 8083 unless $user_conf.key?("port_api")
+  $conf["prefer_local"] = true unless $user_conf.key?("prefer_local")
+  $conf["expose_db"] = true unless $user_conf.key?("expose_db")
 end
 
 # Composing an API url

--- a/conf/containers.yml
+++ b/conf/containers.yml
@@ -25,7 +25,7 @@
   ports:  [ "${conf.port_api}:${conf.port_api}", "${conf.port_web}:${conf.port_web}" ]
   sync:
     - [ "nginx/", "/etc/nginx/conf.d/" ]
-    - [ "ssl/", "/etc/ssl.d/"]
+    - [ "ssl/", "${conf.ssl_prefix}"]
   link:   [ "${conf.hostname_api}:${conf.hostname_api}" ]
   env:
     SERVERNAME_WEB:     ${conf.servername_web}
@@ -35,3 +35,5 @@
     PORT_API:           ${conf.port_api}
     PORT_API_INTERNAL:  ${conf.port_api_internal}
     API_URL:            ${conf.api_url}
+    PORT_KEY_WEB:       ${conf.port_key_web}
+    PORT_KEY_API:       ${conf.port_key_api}

--- a/conf/defaults.yml
+++ b/conf/defaults.yml
@@ -34,6 +34,15 @@ hostname_web:       'web.promis'
 hostname_api:       'api.promis'
 hostname_db:        'db.promis'
 
+# SSL prefix
+ssl_prefix:         '/etc/ssl/private/'
+
+# Standard ssl key names (prefixed with /etc/ssl/private)
+ssl_cert_web:       'promis_fullchain.pem'
+ssl_key_web:        'promis_secretkey.pem'
+ssl_cert_api:       'promis_fullchain.pem'
+ssl_key_api:        'promis_secretkey.pem'
+
 # If set to on, prefer local checkouts over git versions
 prefer_local:       on # set to off here after #17 is fixed
 dir_web:            'repos/promis-frontend'


### PR DESCRIPTION
Config: override key names (and location if you so wish for some reason), put key files in `ssl/` directory. 

NOTE: if you override the key location the container may not set correct permissions. Use at own risk.
