### PR TITLE
YML file for auto-generated configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ sync/
 
 # Deploy-generated stuff
 frontend/deploy/
-backend/api/
+backend/deploy/
 test/deploy/
 
 # Keeper files

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,9 +29,9 @@ ENV["VAGRANT_NO_PARALLEL"] = "yes"
 # to VirtualBox on some Gentoo setups despite configuration
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "docker"
 
-vagrant_root = File.dirname(__FILE__) + "/"
+vagrant_root = File.dirname(__FILE__)
 
-load vagrant_root + "config.rb"
+load File.join(vagrant_root, "config.rb")
 
 # Composing the API url
 need_ext = ($conf["disable_ssl"] && $conf["port_web"] == 80) ||
@@ -39,7 +39,7 @@ need_ext = ($conf["disable_ssl"] && $conf["port_web"] == 80) ||
 $conf["promis_origin"] = $conf["servername_web"] + (need_ext ? "" : ":" + $conf["port_web"].to_s)
 
 # Container definitions
-containers = YAML.load_file(vagrant_root + "conf/containers.yml")
+containers = YAML.load_file(File.join(vagrant_root, "conf", "containers.yml"))
 
 # Check if input contains a configuration variable reference, if so, substitute
 # TODO: better approach
@@ -54,12 +54,12 @@ end
 
 # Process auto-generated files
 # NOTE: this ALWAYS runs even on vagrant-status etc
-generated = YAML.load_file(vagrant_root + "conf/generated.yml")
+generated = YAML.load_file(File.join(vagrant_root, "conf", "/generated.yml"))
 generated.each do | ifname, odirs |
-    s = cfg(IO.read(vagrant_root + ifname))
+    s = cfg(IO.read(File.join(vagrant_root, ifname)))
     bname = File.basename ifname
     odirs.each do | odir |
-        fp = File.open(vagrant_root + odir + "/" + bname, "w")
+        fp = File.open(File.join(vagrant_root, odir, bname), "w")
         fp.puts s
         fp.close
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,19 +53,17 @@ def cfg(input)
 end
 
 # Process auto-generated files
-# TODO: see #46, this needs to live in YML somewhere
-# TODO: this ALWAYS runs even on vagrant-status etc
-ifiles = [ "doc/promis_api.yaml", "frontend/promis.conf" ]
-ofiles = [ [ "backend/api/promis_api.yaml", "frontend/deploy/promis_api.yaml", "test/deploy/promis_api.yaml" ], [ "frontend/deploy/promis.conf" ] ]
-
-ifiles.each_with_index { |v, i|
-  s = cfg(IO.read(v))
-  ofiles[i].each { |vv|
-    fp = File.open(vv, "w")
-    fp.puts s
-    fp.close
-  }
-}
+# NOTE: this ALWAYS runs even on vagrant-status etc
+generated = YAML.load_file(vagrant_root + "conf/generated.yml")
+generated.each do | ifname, odirs |
+    s = cfg(IO.read(vagrant_root + ifname))
+    bname = File.basename ifname
+    odirs.each do | odir |
+        fp = File.open(vagrant_root + odir + "/" + bname, "w")
+        fp.puts s
+        fp.close
+    end
+end
 
 Vagrant.configure("2") do |config|
   config.vm.provider "docker"

--- a/conf/defaults.yml
+++ b/conf/defaults.yml
@@ -54,7 +54,7 @@ sync_web_dir:   '/var/www/promis/sync/'
 sync_web_path:  '/sync/'
 
 # API YML sharing
-yml_api_dir:    '/usr/src/app/api/'
+yml_api_dir:    '/usr/src/app/deploy/'
 yml_web_dir:    '/var/www/promis/api/'
 
 # Standard ssl key names (prefixed with /etc/ssl/private)

--- a/conf/generated.yml
+++ b/conf/generated.yml
@@ -1,0 +1,6 @@
+doc/promis_api.yaml:
+  - frontend/deploy
+  - test/deploy
+  - backend/deploy
+frontend/promis.conf:
+  - frontend/deploy


### PR DESCRIPTION
Files that get pre-processed by Vagrant can now be extended in a pretty self-descriptive `conf/generated.yml` file. Also streamlined the folders a bit so that such files are put in the `deploy` folder in each container (frontend further puts the API YML in `/api/` via `Dockerfile` just as normal).