### PR TITLE
Test container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
-# Making sure Selenium knows where to pick up Gecko from
-env:
-  global:
-    - PATH=$PATH:$TRAVIS_BUILD_DIR
-    - DISPLAY=:99.0
-
 services:
   - docker
 python:
   - "3.4"
 addons:
-  firefox: "49.0"
   apt:
     sources:
       - sourceline: deb http://vagrant-deb.linestarve.com/ any main
     packages:
       - vagrant
-install: "pip3 install --user -r ./test/requirements.txt"
 before_script:
   - .travis/setup.sh
 script:
   - ./backend_test; CODE_B=$?
   - ./integration_test; CODE_I=$?
   - if [ $CODE_B -ne 0 -o $CODE_I -ne 0 ]; then exit 1; fi
-  
+
 notifications:
   slack:
     secure: Xp+fsWqgB/rbZxkSkGlB4qXXaNs46zXPkNxWQi5DhSKr45vKPIqf5707sIEGTv4eNlnZlGmiiUTKnkcYmJ9PpsLitFDcvZ1QyiNpVGwvwItFU4PPoCGNiBoo3G0qT5VtnTME8Bo83ai0+M8SUmlaLQPUTKVvWKBfiStJ7A0MElXsLYPri4Zv9m1UzVllFD+/IDgEjPoszY4SSV4f3swTRNC6MZ8QRdUSOfGuqHKgrNqrjUmoSAbZCSIrzy5uq/BC6BcJuEHER5ElFaCNe1jFyS/nwYHhR7COsRp+QUk7OeNe2L+EBVNRvmhjzoBu3j5uuN4Ni8p/NIK5oZ+fy3zsp10NMJ9PT1bvBoxxfkMcXK28bl+Vg7GkaRPOK4D1/MfRHolpTqsS/RuWXrOfIKxaWLErxekn9Qg+zJBndtIHDUmYAvJBXLAuQM84e+a+lk6/auPJbYC7UwrCValn6pqO9l6F+mfRpZrOWgNvGpmc5P+8FOXX8QZljaTlUEDlqWoM+8Rkb4fYibT7H+P+rAQJDmhnFtprOsyDXqFmvN8VZXSnyLJtR34JTuxhC45k5F3oeo6utwNNTOo6TsY+/f4k+ZkDVec3IbedZaIHowWShqrZD5lgFjYn+Rs/zYdORulB/UWPRtREF0cA7QxdJHYBT5SliHFye2B9XYB2JgzT5WM=

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -25,7 +25,7 @@ POSTGIS_PORT=4242
 echo "port_sql_host: $POSTGIS_PORT" >> conf/conf.yml
 
 # Ready, steady, go
-vagrant up
+vagrant up db.promis api.promis web.promis test.promis
 
 # Download the Firefox driver for Selenium
 # TODO: any chance to apt-get so we can put this to travis.yml?

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,21 +1,5 @@
 #!/bin/sh
 
-# Starting a virtual display
-sh -e /etc/init.d/xvfb start
-
-# FTP server
-mkdir ftproot
-cd ftproot
-python3 -m pyftpdlib > /tmp/ftp.log 2>&1 &
-echo "=> FTP service started"
-
-# Generate data for FTP
-../test/data/generate.py
-cd -
-
-# Waiting to split the output and start up X
-sleep 3
-
 # Setting up a minimal viable config
 echo "development_setup: yes" > conf/conf.yml
 
@@ -26,11 +10,6 @@ echo "port_sql_host: $POSTGIS_PORT" >> conf/conf.yml
 
 # Ready, steady, go
 vagrant up db.promis api.promis web.promis test.promis
-
-# Download the Firefox driver for Selenium
-# TODO: any chance to apt-get so we can put this to travis.yml?
-wget https://github.com/mozilla/geckodriver/releases/download/v0.13.0/geckodriver-v0.13.0-linux64.tar.gz
-tar -xf geckodriver-v0.13.0-linux64.tar.gz
 
 # Wait for the backend to start up
 while ! docker logs api.promis | grep 'at http://0.0.0.0:80/' > /dev/null; do

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,7 +70,7 @@ ifiles.each_with_index { |v, i|
 Vagrant.configure("2") do |config|
   config.vm.provider "docker"
   containers.each do |container|
-    config.vm.define cfg(container["name"]) do |node|
+    config.vm.define cfg(container["name"]), autostart: ! container["noauto"] do |node|
       # Removing the default folder sync
       node.vm.synced_folder ".", "/vagrant", disabled: true
 
@@ -123,7 +123,6 @@ Vagrant.configure("2") do |config|
             docker.env[env[0]] = cfg(env[1])
           end
         end
-
         docker.name = cfg(container["name"])
       end
     end

--- a/conf/containers.yml
+++ b/conf/containers.yml
@@ -39,3 +39,8 @@
     PORT_KEY_WEB:       ${conf.port_key_web}      # erm what's that?
     SYNC_PATH:          ${conf.sync_web_path}
     YML_PATH:           ${conf.yml_web_dir}
+
+- name: ${conf.hostname_test}
+  build: ${conf.dir_test}
+  ports:  [ "${conf.port_ftp_test}" ]
+  noauto: true

--- a/conf/containers.yml
+++ b/conf/containers.yml
@@ -42,5 +42,5 @@
 
 - name: ${conf.hostname_test}
   build: ${conf.dir_test}
-  ports:  [ "${conf.port_ftp_test}" ]
+  ports:  [ "${conf.port_ftp_test}", "${conf.port_ftp_passive}" ]
   noauto: true

--- a/conf/defaults.yml
+++ b/conf/defaults.yml
@@ -24,6 +24,8 @@ port_api_internal:  80
 
 # Port for the test container FTP
 port_ftp_test:      2121
+# TODO: vagrant seems only open one port instead of a range, do we need a range?
+port_ftp_passive:   6000
 
 # Set to true in conf.yml to disable SSL for local testing
 disable_ssl:        off

--- a/conf/defaults.yml
+++ b/conf/defaults.yml
@@ -18,8 +18,12 @@ postgres_dbname:    'promisdb'
 # DNS domain names and ports for frontend and API respectively
 servername_web:     'promis.ikd.kiev.ua'
 port_web:           443
+
 # Port that Backend listens on internally
 port_api_internal:  80
+
+# Port for the test container FTP
+port_ftp_test:      2121
 
 # Set to true in conf.yml to disable SSL for local testing
 disable_ssl:        off
@@ -44,6 +48,7 @@ django_key:         ''
 hostname_web:       'web.promis'
 hostname_api:       'api.promis'
 hostname_db:        'db.promis'
+hostname_test:      'test.promis'
 
 # SSL prefix
 ssl_prefix:         '/etc/ssl/private/'
@@ -66,7 +71,7 @@ ssl_key_api:        'promis_secretkey.pem'
 # If set to on, prefer local checkouts over git versions
 dir_web:            'frontend'
 dir_api:            'backend'
-# dir_test: TODO
+dir_test:           'test'
 
 # Override to true/on/yes in conf.yml to cause a boot2docker VM to be run
 # regardless of vagrant's own judgment

--- a/docker_utils
+++ b/docker_utils
@@ -70,14 +70,17 @@ case `basename $0` in
     backend_bash)
     run_docker api.promis bash
     ;;
-    
+
     backend_test)
     run_docker api.promis py.test -v promis/
     fix_exit_code
     ;;
-    
+
     integration_test)
-    py.test -v test/
+    if ! vagrant status test.promis 2>&1 | grep 'running (docker)' >/dev/null; then
+      vagrant up test.promis
+    fi
+    run_docker test.promis py.test -v
     fix_exit_code
     ;;
 esac

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,9 @@
+FROM weihan/webdriver-python
+
+RUN mkdir -p /usr/src/test
+WORKDIR /usr/src/test
+COPY requirements.txt /usr/src/test/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /usr/src/test
+
+CMD [ "/usr/src/test/start_ftp.sh" ]

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,2 @@
 pytest
-selenium
 pyftpdlib
-requests
-PyYAML

--- a/test/start_ftp.sh
+++ b/test/start_ftp.sh
@@ -2,4 +2,4 @@
 mkdir -p ftp
 cd ftp
 python ../data/generate.py
-python -m pyftpdlib
+python -m pyftpdlib -n 172.17.0.1 -r 6000-6000

--- a/test/start_ftp.sh
+++ b/test/start_ftp.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p ftp
+cd ftp
+python ../data/generate.py
+python -m pyftpdlib

--- a/test/tests_backend/auth.py
+++ b/test/tests_backend/auth.py
@@ -7,7 +7,14 @@ def _get_origin():
     # TODO: disover path on our own
     # TODO: discuss whether we need YML at all?
     with open("deploy/promis_api.yaml") as fp:
-        return yaml.load(fp)["host"]
+        origin =  yaml.load(fp)["host"].split(":")
+
+        # Translate loopback address to docker inter-container interface
+        if origin[0] == "localhost" or origin[0] == "127.0.0.1":
+            origin[0] = "172.17.0.1"
+        if len(origin) > 1:
+            origin[0] += ":" + origin[1]
+        return origin[0]
 
 class Session:
     '''Temporary class to envelop a session'''

--- a/test/tests_backend/auth.py
+++ b/test/tests_backend/auth.py
@@ -5,7 +5,8 @@ import requests, re, yaml
 
 def _get_origin():
     # TODO: disover path on our own
-    with open("test/deploy/promis_api.yaml") as fp:
+    # TODO: discuss whether we need YML at all?
+    with open("deploy/promis_api.yaml") as fp:
         return yaml.load(fp)["host"]
 
 class Session:


### PR DESCRIPTION
New container `test.promis` for carrying out the testing in an automated form. 
- Does not autostart
- Start with `vagrant up test.promis`
- Use with `./integration_test` (implicitly starts the container too)
- Removed a lot of litter in Travis config that is now moved inside the container
- As the container spins it creates an FTP server with test data on port 2121 (forwarded to the host)
- Code still usable on the host

*NOTE*: Please merge `backend_testing` first as I depend on it.