### PR TITLE
API changes

### DIFF
--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -201,7 +201,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Session'
+              $ref: '#/definitions/IdURL'
         default:
           description: Unexpected error
           schema:

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -435,93 +435,208 @@ paths:
 definitions:
   Project:
     type: object
-    allOf:
-      - $ref: '#/definitions/IdURL'
-      - $ref: '#/definitions/NameDesc'
-      - properties:
-          timelapse:
-            $ref: '#/definitions/Time'
+    # cut here, #193
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+      name:
+        type: string
+        description: Short name
+      desc:
+        type: string
+        description: In-depth description
+    #allOf:
+      #- $ref: '#/definitions/IdURL'
+      #- $ref: '#/definitions/NameDesc'
+      #- properties:
+      timelapse:
+        $ref: '#/definitions/Time'
 
   Device:
     type: object
-    allOf:
-      - $ref: '#/definitions/IdURL'
-      - $ref: '#/definitions/NameDesc'
-      - properties:
-          channels:
-            type: array
-            description: Channels the device provides
-            items:
-              $ref: '#/definitions/IdURL'
+    # cut here, #193
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+      name:
+        type: string
+        description: Short name
+      desc:
+        type: string
+        description: In-depth description
+    #allOf:
+      #- $ref: '#/definitions/IdURL'
+      #- $ref: '#/definitions/NameDesc'
+      #- properties:
+      channels:
+        type: array
+        description: Channels the device provides
+        items:
+          $ref: '#/definitions/IdURL'
 
   Channel:
     type: object
-    allOf:
-      - $ref: '#/definitions/IdURL'
-      - $ref: '#/definitions/NameDesc'
+    # cut here, #193
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+      name:
+        type: string
+        description: Short name
+      desc:
+        type: string
+        description: In-depth description
+    #allOf:
+      #- $ref: '#/definitions/IdURL'
+      #- $ref: '#/definitions/NameDesc'
 
   Parameter:
     type: object
-    allOf:
-      - $ref: '#/definitions/IdURL'
-      - $ref: '#/definitions/NameDesc'
-      - properties:
-          channel:
-            allOf:
-              - description: Channel the parameter depends on
-              - $ref: '#/definitions/IdURL'
+    # cut here, #193
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+      name:
+        type: string
+        description: Short name
+      desc:
+        type: string
+        description: In-depth description
+    #allOf:
+      #- $ref: '#/definitions/IdURL'
+      #- $ref: '#/definitions/NameDesc'
+      #- properties:
+      channel:
+            #allOf:
+              #- description: Channel the parameter depends on
+              #- $ref: '#/definitions/IdURL'
+        $ref: '#/definitions/IdURL'
 
   Session:
     type: object
-    allOf:
-      - $ref: '#/definitions/IdURL'
-      - properties:
-          project:
-            type: integer
-            description: Related project ID
-          orbit:
-            type: number
-            description: Orbit representation
-          geoline:
-            $ref: '#/definitions/GeoLine'
-          measurements:
-            type: array # api links to measurement instances
-            description: Available measurements for this session
-            items:
-              $ref: '#/definitions/IdURL'
-          timelapse:
-            $ref: '#/definitions/Time'
+    # cut here, #193
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+    #allOf:
+      #- $ref: '#/definitions/IdURL'
+      #- properties:
+          #project:
+            #type: integer
+            #description: Related project ID
+          #orbit:
+            #type: number
+            #description: Orbit representation
+          #geoline:
+            #$ref: '#/definitions/GeoLine'
+          #measurements:
+            #type: array # api links to measurement instances
+            #description: Available measurements for this session
+            #items:
+              #$ref: '#/definitions/IdURL'
+          #timelapse:
+            #$ref: '#/definitions/Time'
+        project:
+          type: integer
+          description: Related project ID
+        orbit:
+          type: number
+          description: Orbit representation
+        geoline:
+          $ref: '#/definitions/GeoLine'
+        measurements:
+          type: array # api links to measurement instances
+          description: Available measurements for this session
+          items:
+            $ref: '#/definitions/IdURL'
+        timelapse:
+          $ref: '#/definitions/Time'
+
 
   Measurement:
     type: object
-    allOf:
-      - $ref: '#/definitions/IdURL'
-      - properties:
-          session:
-            $ref: '#/definitions/IdURL'
-          channel:
-            $ref: '#/definitions/IdURL'
-          parameter:
-            $ref: '#/definitions/IdURL'
-          freq:
-            type: number
-            description: Sampling frequency
-          min_freq:
-            type: number
-          max_freq:
-            type: number
-          channel_quicklook:
-            type: string
-            description: URL to channel quicklook
-          channel_download:
-            type: string
-            description: URL to channel data download
-          parameter_quicklook:
-            type: string
-            description: URL to parameter quicklook
-          parameter_download:
-            type: string
-            description: URL to parameter data download
+    # cut here, #193
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+    #allOf:
+      #- $ref: '#/definitions/IdURL'
+      #- properties:
+          #session:
+            #$ref: '#/definitions/IdURL'
+          #channel:
+            #$ref: '#/definitions/IdURL'
+          #parameter:
+            #$ref: '#/definitions/IdURL'
+          #freq:
+            #type: number
+            #description: Sampling frequency
+          #min_freq:
+            #type: number
+          #max_freq:
+            #type: number
+          #channel_quicklook:
+            #type: string
+            #description: URL to channel quicklook
+          #channel_download:
+            #type: string
+            #description: URL to channel data download
+          #parameter_quicklook:
+            #type: string
+            #description: URL to parameter quicklook
+          #parameter_download:
+            #type: string
+            #description: URL to parameter data download
+        session:
+          $ref: '#/definitions/IdURL'
+        channel:
+          $ref: '#/definitions/IdURL'
+        parameter:
+          $ref: '#/definitions/IdURL'
+        freq:
+          type: number
+          description: Sampling frequency
+        min_freq:
+          type: number
+        max_freq:
+          type: number
+        channel_quicklook:
+          type: string
+          description: URL to channel quicklook
+        channel_download:
+          type: string
+          description: URL to channel data download
+        parameter_quicklook:
+          type: string
+          description: URL to parameter quicklook
+        parameter_download:
+          type: string
+          description: URL to parameter data download
+
   Quicklook:
     type: object
     properties:

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: Promis API
   description: Development version, a subject to change
-  version: "0.1.1"
+  version: "0.1.2"
 
 # the domain of the service
 # (to be changed by deploy)
@@ -481,84 +481,62 @@ paths:
 definitions:
   Project:
     type: object
-    properties:
-      id:
-        type: number
-        description: Unique project ID
-      name:
-        type: string
-        description: Name of the project
-      desc:
-        type: string
-        description: Description of the project
-      timelapse:
-        $ref: '#/definitions/Time'
+    allOf:
+      - $ref: '#/definitions/IdURL'
+      - $ref: '#/definitions/NameDesc'
+      - properties:
+          timelapse:
+            $ref: '#/definitions/Time'
 
   Device:
     type: object
-    properties:
-      id:
-        type: number
-        description: Unique device ID
-      name:
-        type: string
-        description: Short name of the device
-      desc:
-        type: string
-        description: Detailed info about the device
-      channels:
-        type: array
-        items:
-          type: string
+    allOf:
+      - $ref: '#/definitions/IdURL'
+      - $ref: '#/definitions/NameDesc'
+      - properties:
+          channels:
+            type: array
+            description: Channels the device provides
+            items:
+              $ref: '#/definitions/IdURL'
 
   Channel:
     type: object
-    properties:
-      id:
-        type: number
-        description: Unique channel ID
-      name:
-        type: string
-        description: Short name of the channel
+    allOf:
+      - $ref: '#/definitions/IdURL'
+      - $ref: '#/definitions/NameDesc'
 
   Parameter:
     type: object
-    properties:
-      id:
-        type: number
-        description: Unique parameter ID
-      name:
-        type: string
-        description: Short name of the parameter
-      description:
-        type: string
-        description: Detailed parameter information
-      channel:
-        type: string
-        description: URL to corresponding channel
+    allOf:
+      - $ref: '#/definitions/IdURL'
+      - $ref: '#/definitions/NameDesc'
+      - properties:
+          channel:
+            allOf:
+              - description: Channel the parameter depends on
+              - $ref: '#/definitions/IdURL'
 
   Session:
     type: object
-    properties:
-      id:
-        type: integer
-        description: Unique session ID
-      project:
-        type: integer
-        description: Related project ID
-      orbit:
-        type: number
-        description: Orbit representation
-      geoline:
-        type: string
-        description: Where data has been measured
-      measurements:
-        type: array # api links to measurement instances
-        description: Available measurements for this session
-        items:
-          type: string
-      time:
-        $ref: '#/definitions/Time'
+    allOf:
+      - $ref: '#/definitions/IdURL'
+      - properties:
+          project:
+            type: integer
+            description: Related project ID
+          orbit:
+            type: number
+            description: Orbit representation
+          geoline:
+            $ref: '#/definitions/GeoLine'
+          measurements:
+            type: array # api links to measurement instances
+            description: Available measurements for this session
+            items:
+              $ref: '#/definitions/IdURL'
+          timelapse:
+            $ref: '#/definitions/Time'
 
   Measurement:
     type: object
@@ -571,7 +549,7 @@ definitions:
     type: object
     properties:
       data:
-        type: string
+        type: array
         description: Quicklook data
 
   RawData:
@@ -585,10 +563,22 @@ definitions:
   Time:
     type: object
     properties:
-      begin:
-        type: string
+      start:
+        type: integer
+        description: UNIX time at UTC
       end:
-        type: string
+        type: integer
+        description: UNIX time at UTC
+
+  # 3D geoline
+  GeoLine:
+    type: array
+    items:
+      type: array
+      description: Coordinates at 1 Hz
+      items:
+        type: number
+        description: Latitude, Longitude, Altitude
 
   # Error message
   Error:
@@ -597,3 +587,23 @@ definitions:
       message:
         type: string
         description: Error message
+
+  # Common components
+  IdURL:
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+
+  NameDesc:
+    properties:
+      name:
+        type: string
+        description: Short name
+      desc:
+        type: string
+        description: In-depth description
+

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -510,7 +510,18 @@ definitions:
             type: number
           max_freq:
             type: number
-
+          channel_quicklook:
+            type: string
+            description: URL to channel quicklook
+          channel_download:
+            type: string
+            description: URL to channel data download
+          parameter_quicklook:
+            type: string
+            description: URL to parameter quicklook
+          parameter_download:
+            type: string
+            description: URL to parameter data download
   Quicklook:
     type: object
     properties:

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -56,7 +56,12 @@ paths:
       description: |
         Retrieve particular space project
       parameters:
-        - $ref: '#/parameters/Id'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
       responses:
         200:
           description: Space project
@@ -106,7 +111,12 @@ paths:
       description: |
         Get particular satellite device
       parameters:
-        - $ref: '#/parameters/Id'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
       responses:
         200:
           description: Satellite device
@@ -156,7 +166,12 @@ paths:
       description: |
         Get particular channel
       parameters:
-        - $ref: '#/parameters/Id'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
       responses:
         200:
           description: Satellite channel
@@ -183,6 +198,7 @@ paths:
           in: query
           description: Project ID to query its sessions for
           type: integer
+        # #193: we can fold that too:
         - name: fromtime
           in: query
           description: From time, UNIX timestamp at UTC
@@ -219,7 +235,12 @@ paths:
       description: |
         Retrieve single session
       parameters:
-        - $ref: '#/parameters/Id'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
       responses:
         200:
           description: Measurement session
@@ -288,7 +309,12 @@ paths:
       description: |
         Get particular measurement
       parameters:
-        - $ref: '#/parameters/Id'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
       responses:
         200:
           description: Measurement
@@ -345,7 +371,12 @@ paths:
       description: |
         Get particular parameter
       parameters:
-        - $ref: '#/parameters/Id'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
       responses:
         200:
           description: Parameter
@@ -370,12 +401,37 @@ paths:
       description: |
         This endpoint allows to get a quicklook of certain data measurement.
       parameters:
-        - $ref: '#/parameters/Id'
-        - $ref: '#/parameters/Source'
-        - $ref: '#/parameters/FromTime'
-        - $ref: '#/parameters/ToTime'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
+        - name: source
+          in: path
+          type: string
+          description: Where to take the data from
+          required: true
+          enum:
+            - parameter
+            - channel
+        #- $ref: '#/parameters/Source'
+        #- $ref: '#/parameters/FromTime'
+        #- $ref: '#/parameters/ToTime'
+        #- $ref: '#/parameters/Polygon'
+        - name: fromtime
+          in: query
+          description: From time, UNIX timestamp at UTC
+          type: integer
+        - name: totime
+          in: query
+          description: To time, UNIX timestamp at UTC
+          type: integer
         # TODO: in future release
-        - $ref: '#/parameters/Polygon'
+        - name: polygon
+          description: WKT polygon with desired search area
+          in: query
+          type: string
         - name: points
           in: query
           type: integer
@@ -403,12 +459,37 @@ paths:
       description: |
         This endpoint allows to get a quicklook of certain data measurement.
       parameters:
-        - $ref: '#/parameters/Id'
-        - $ref: '#/parameters/Source'
-        - $ref: '#/parameters/FromTime'
-        - $ref: '#/parameters/ToTime'
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Unique numerical identifier
+        # $ref: '#/parameters/Id' # #193
+        - name: source
+          in: path
+          type: string
+          description: Where to take the data from
+          required: true
+          enum:
+            - parameter
+            - channel
+        #- $ref: '#/parameters/Source'
+        #- $ref: '#/parameters/FromTime'
+        #- $ref: '#/parameters/ToTime'
+        #- $ref: '#/parameters/Polygon'
+        - name: fromtime
+          in: query
+          description: From time, UNIX timestamp at UTC
+          type: integer
+        - name: totime
+          in: query
+          description: To time, UNIX timestamp at UTC
+          type: integer
         # TODO: in future release
-        - $ref: '#/parameters/Polygon'
+        - name: polygon
+          description: WKT polygon with desired search area
+          in: query
+          type: string
         # TODO: - required not working - put it on the deeper links
         - name: fmt
           in: query
@@ -556,21 +637,21 @@ definitions:
               #$ref: '#/definitions/IdURL'
           #timelapse:
             #$ref: '#/definitions/Time'
-        project:
-          type: integer
-          description: Related project ID
-        orbit:
-          type: number
-          description: Orbit representation
-        geoline:
-          $ref: '#/definitions/GeoLine'
-        measurements:
-          type: array # api links to measurement instances
-          description: Available measurements for this session
-          items:
-            $ref: '#/definitions/IdURL'
-        timelapse:
-          $ref: '#/definitions/Time'
+      project:
+        type: integer
+        description: Related project ID
+      orbit:
+        type: number
+        description: Orbit representation
+      geoline:
+        $ref: '#/definitions/GeoLine'
+      measurements:
+        type: array # api links to measurement instances
+        description: Available measurements for this session
+        items:
+          $ref: '#/definitions/IdURL'
+      timelapse:
+        $ref: '#/definitions/Time'
 
 
   Measurement:
@@ -611,31 +692,31 @@ definitions:
           #parameter_download:
             #type: string
             #description: URL to parameter data download
-        session:
-          $ref: '#/definitions/IdURL'
-        channel:
-          $ref: '#/definitions/IdURL'
-        parameter:
-          $ref: '#/definitions/IdURL'
-        freq:
-          type: number
-          description: Sampling frequency
-        min_freq:
-          type: number
-        max_freq:
-          type: number
-        channel_quicklook:
-          type: string
-          description: URL to channel quicklook
-        channel_download:
-          type: string
-          description: URL to channel data download
-        parameter_quicklook:
-          type: string
-          description: URL to parameter quicklook
-        parameter_download:
-          type: string
-          description: URL to parameter data download
+      session:
+       $ref: '#/definitions/IdURL'
+      channel:
+       $ref: '#/definitions/IdURL'
+      parameter:
+       $ref: '#/definitions/IdURL'
+      freq:
+       type: number
+       description: Sampling frequency
+      min_freq:
+       type: number
+      max_freq:
+       type: number
+      channel_quicklook:
+       type: string
+       description: URL to channel quicklook
+      channel_download:
+       type: string
+       description: URL to channel data download
+      parameter_quicklook:
+       type: string
+       description: URL to parameter quicklook
+      parameter_download:
+       type: string
+       description: URL to parameter data download
 
   Quicklook:
     type: object
@@ -756,4 +837,3 @@ parameters:
     description: WKT polygon with desired search area
     in: query
     type: string
-

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -197,14 +197,14 @@ paths:
           type: integer
         - name: fromtime
           in: query
-          description: From time
-          type: string
+          description: From time, UNIX timestamp at UTC
+          type: integer
         - name: totime
           in: query
-          description: To time
-          type: string
+          description: To time, UNIX timestamp at UTC
+          type: integer
         - name: polygon
-          description: Geo polygon with desired search area
+          description: WKT polygon with desired search area
           in: query
           type: string
       responses:
@@ -381,8 +381,9 @@ paths:
             $ref: '#/definitions/Error'
 
   # TODO: here and below, add /channel and /parameter paths
+  # TODO: reuse parameters across several paths
   # Quicklook
-  /quicklook/{id}:
+  /quicklook/{id}/{source}:
     x-swagger-object-key: id
     x-swagger-router-view: QuicklookView
     get:
@@ -402,6 +403,27 @@ paths:
           type: integer
           required: false
           description: Amount of data points to show on the quicklook.
+        - name: source
+          in: path
+          type: string
+          description: Where to take the data from
+          required: true
+          enum:
+            - parameter
+            - channel
+        - name: fromtime
+          in: query
+          description: From time, UNIX timestamp at UTC
+          type: integer
+        - name: totime
+          in: query
+          description: To time, UNIX timestamp at UTC
+          type: integer
+        # TODO: in future release
+        - name: polygon
+          description: WKT polygon with desired search area
+          in: query
+          type: string
       responses:
         200:
           description: Quicklook data
@@ -413,7 +435,7 @@ paths:
             $ref: '#/definitions/Error'
 
   # Data download
-  /download/{id}:
+  /download/{id}/{source}:
     x-swagger-object-key: id
     x-swagger-router-view: DownloadView
     get:
@@ -428,17 +450,39 @@ paths:
           in: path
           type: string
           required: true
+        - name: source
+          in: path
+          type: string
+          description: Where to take the data from
+          required: true
+          enum:
+            - parameter
+            - channel
+        - name: fromtime
+          in: query
+          description: From time, UNIX timestamp at UTC
+          type: integer
+        - name: totime
+          in: query
+          description: To time, UNIX timestamp at UTC
+          type: integer
+        # TODO: in future release
+        - name: polygon
+          description: WKT polygon with desired search area
+          in: query
+          type: string
         # TODO: - required not working - put it on the deeper links
-        # - name: fmt
-        #   in: query
-        #   type: string
-        #   required: false
-        #   description: Format name to download data in.
-        #   default: json
-        #   enum:
-        #     - json
-        #     - ascii
-        #     - netcdf
+        - name: fmt
+          in: query
+          type: string
+          required: false
+          description: Format name to download data in.
+          default: json
+          enum:
+            - json
+            - ascii
+            - csv
+            - netcdf
       responses:
         200:
           description: Raw data
@@ -446,34 +490,6 @@ paths:
             $ref: '#/definitions/RawData'
         default:
           description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
-  # testing multiaction endpoint
-  /data/{id}/{action}:
-    x-swagger-router-view: DownloadData
-    get:
-      summary: Download data
-      tags:
-        - Measurements
-      description: Single endpoint for two actions. Untested!
-      parameters:
-        - name: id
-          in: path
-          type: string
-          required: true
-        - name: action
-          in: path
-          type: string
-          required: true
-          enum:
-            - download
-            - quicklook
-      responses:
-        200:
-          description: JSON data
-        default:
-          description: Error
           schema:
             $ref: '#/definitions/Error'
 
@@ -540,10 +556,22 @@ definitions:
 
   Measurement:
     type: object
-    properties:
-      url:
-        description: API URL to certain Measurement
-        type: string
+    allOf:
+      - $ref: '#/definitions/IdURL'
+      - properties:
+          session:
+            $ref: '#/definitions/IdURL'
+          channel:
+            $ref: '#/definitions/IdURL'
+          parameter:
+            $ref: '#/definitions/IdURL'
+          freq:
+            type: number
+            description: Sampling frequency
+          min_freq:
+            type: number
+          max_freq:
+            type: number
 
   Quicklook:
     type: object
@@ -551,6 +579,15 @@ definitions:
       data:
         type: array
         description: Quicklook data
+      geoline:
+        $ref: '#/definitions/GeoLine'
+      timelapse:
+        $ref: '#/definitions/Time'
+      source:
+        # TODO: technically it can also be a parameter but whatever
+        $ref: '#/definitions/Channel'
+      value:
+        $ref: '#/definitions/Value'
 
   RawData:
     type: object
@@ -569,6 +606,19 @@ definitions:
       end:
         type: integer
         description: UNIX time at UTC
+
+  # Physical value
+  Value:
+    type: object
+    properties:
+      name:
+        type: string
+      symbol:
+        type: string
+        description: The symbol or the letter used to denote the value
+      units:
+        type: string
+        description: The abbreviated form of the units the value is measured in
 
   # 3D geoline
   GeoLine:

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -56,11 +56,7 @@ paths:
       description: |
         Retrieve particular space project
       parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Project ID
+        - $ref: '#/parameters/Id'
       responses:
         200:
           description: Space project
@@ -110,11 +106,7 @@ paths:
       description: |
         Get particular satellite device
       parameters:
-        - name: id
-          in: path
-          required: true
-          type: integer
-          description: Device ID
+        - $ref: '#/parameters/Id'
       responses:
         200:
           description: Satellite device
@@ -164,11 +156,7 @@ paths:
       description: |
         Get particular channel
       parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Channel ID
+        - $ref: '#/parameters/Id'
       responses:
         200:
           description: Satellite channel
@@ -231,11 +219,7 @@ paths:
       description: |
         Retrieve single session
       parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Session ID
+        - $ref: '#/parameters/Id'
       responses:
         200:
           description: Measurement session
@@ -304,11 +288,7 @@ paths:
       description: |
         Get particular measurement
       parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Measurement ID
+        - $ref: '#/parameters/Id'
       responses:
         200:
           description: Measurement
@@ -365,11 +345,7 @@ paths:
       description: |
         Get particular parameter
       parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Parameter ID
+        - $ref: '#/parameters/Id'
       responses:
         200:
           description: Parameter
@@ -394,36 +370,17 @@ paths:
       description: |
         This endpoint allows to get a quicklook of certain data measurement.
       parameters:
-        - name: id
-          in: path
-          type: string
-          required: true
+        - $ref: '#/parameters/Id'
+        - $ref: '#/parameters/Source'
+        - $ref: '#/parameters/FromTime'
+        - $ref: '#/parameters/ToTime'
+        # TODO: in future release
+        - $ref: '#/parameters/Polygon'
         - name: points
           in: query
           type: integer
           required: false
           description: Amount of data points to show on the quicklook.
-        - name: source
-          in: path
-          type: string
-          description: Where to take the data from
-          required: true
-          enum:
-            - parameter
-            - channel
-        - name: fromtime
-          in: query
-          description: From time, UNIX timestamp at UTC
-          type: integer
-        - name: totime
-          in: query
-          description: To time, UNIX timestamp at UTC
-          type: integer
-        # TODO: in future release
-        - name: polygon
-          description: WKT polygon with desired search area
-          in: query
-          type: string
       responses:
         200:
           description: Quicklook data
@@ -446,31 +403,12 @@ paths:
       description: |
         This endpoint allows to get a quicklook of certain data measurement.
       parameters:
-        - name: id
-          in: path
-          type: string
-          required: true
-        - name: source
-          in: path
-          type: string
-          description: Where to take the data from
-          required: true
-          enum:
-            - parameter
-            - channel
-        - name: fromtime
-          in: query
-          description: From time, UNIX timestamp at UTC
-          type: integer
-        - name: totime
-          in: query
-          description: To time, UNIX timestamp at UTC
-          type: integer
+        - $ref: '#/parameters/Id'
+        - $ref: '#/parameters/Source'
+        - $ref: '#/parameters/FromTime'
+        - $ref: '#/parameters/ToTime'
         # TODO: in future release
-        - name: polygon
-          description: WKT polygon with desired search area
-          in: query
-          type: string
+        - $ref: '#/parameters/Polygon'
         # TODO: - required not working - put it on the deeper links
         - name: fmt
           in: query
@@ -656,4 +594,40 @@ definitions:
       desc:
         type: string
         description: In-depth description
+
+parameters:
+  Id:
+    name: id
+    in: path
+    type: integer
+    required: true
+    description: Unique numerical identifier
+
+  Source:
+    name: source
+    in: path
+    type: string
+    description: Where to take the data from
+    required: true
+    enum:
+      - parameter
+      - channel
+
+  FromTime:
+    name: fromtime
+    in: query
+    description: From time, UNIX timestamp at UTC
+    type: integer
+
+  ToTime:
+    name: totime
+    in: query
+    description: To time, UNIX timestamp at UTC
+    type: integer
+
+  Polygon:
+    name: polygon
+    description: WKT polygon with desired search area
+    in: query
+    type: string
 


### PR DESCRIPTION
Highlights:
- Lots of reuse added
- Every object has a `id` / `url` pair of properties
- Listing dependent components (e.g. channel the parameter is built upon) produces `id` / `url` pairs as well without deserialising the whole thing
- Listing sessions gives a list of `id` / `url` pairs, other listings deserialise stuff
- "Roadmap" download entrypoint removed and replaced with links in the measurement entrypoint, I think it will make way more sense (NOTE: this will break tests when we implement that)