### PR TITLE
Migrations won't get in the way

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
+
+# NOTE: this copies everything, but only promis directory reloads
+# As such, the migration files auto-created on the container will
+# be lost when the container is deleted
 COPY . /usr/src/app
 
 CMD [ "/usr/src/app/run_promis.sh" ]

--- a/backend/promis/backend_api/migrations
+++ b/backend/promis/backend_api/migrations
@@ -1,0 +1,1 @@
+../../migrations


### PR DESCRIPTION
The migrations now live in `/backend/migrations`. It's symlinked in the usual place inside `/backend/promis` too. The effect is that there is a _copy_ on the container and not a _mount_, so that the migration files auo-created by Django won't get transported back to the host filesystem.