### PR TITLE
Serializer update

### DIFF
--- a/backend/promis/backend_api/fixtures/init_data.json
+++ b/backend/promis/backend_api/fixtures/init_data.json
@@ -92,21 +92,21 @@
     "model": "backend_api.device",
     "pk": 1,
     "fields": {
-        "satellite": 1
+        "space_project": 1
     }
 },
 {
     "model": "backend_api.device",
     "pk": 2,
     "fields": {
-        "satellite": 1
+        "space_project": 1
     }
 },
 {
     "model": "backend_api.device",
     "pk": 3,
     "fields": {
-        "satellite": 1
+        "space_project": 1
     }
 },
 {

--- a/backend/promis/backend_api/models.py
+++ b/backend/promis/backend_api/models.py
@@ -78,7 +78,7 @@ class Space_project(TranslatableModel):
 
 
 class Device(TranslatableModel):
-    satellite = ForeignKey('Space_project')
+    space_project = ForeignKey('Space_project')
 
     translations = TranslatedFields(
         name = TextField(),

--- a/backend/promis/backend_api/serializer.py
+++ b/backend/promis/backend_api/serializer.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
 from backend_api import helpers
 import util.parsers
-
+import util.unix_time
 
 class LookupById:
     '''Shortcut to include extra_kwargs to every Meta class'''
@@ -25,8 +25,8 @@ class SpaceProjectsSerializer(TranslatableModelSerializer):
 
     def get_timelapse(self, obj):
         # TODO: start and end are a DATE not DATETIME, but we convert them implicitly
-        return { 'start': util.parsers.datetime_to_utc(obj.date_start),
-                 'end': util.parsers.datetime_to_utc(obj.date_end) }
+        return { 'start': util.unix_time.datetime_to_utc(obj.date_start),
+                 'end': util.unix_time.datetime_to_utc(obj.date_end) }
 
     class Meta(LookupById):
         model = models.Space_project
@@ -80,8 +80,8 @@ class SessionsSerializer(serializers.ModelSerializer):
 
     def get_time(self, obj):
         # TODO: change to time_start in model for consistency
-        return { 'start': util.parsers.datetime_to_utc(obj.time_begin),
-                 'end': util.parsers.datetime_to_utc(obj.time_end) }
+        return { 'start': util.unix_time.datetime_to_utc(obj.time_begin),
+                 'end': util.unix_time.datetime_to_utc(obj.time_end) }
 
 
     class Meta(LookupById):

--- a/backend/promis/backend_api/serializer.py
+++ b/backend/promis/backend_api/serializer.py
@@ -60,6 +60,21 @@ class ChannelsSerializer(HyperlinkedTranslatableModelSerializer):
                 self.fields.pop(f)
 
 
+class ParametersSerializer(TranslatableModelSerializer):
+    channel = ChannelsSerializer(idurl = True)
+
+    class Meta(LookupById):
+        fields = ('id', 'url', 'name', 'description', 'channel')
+        model = models.Parameter
+
+    # TODO: STUB
+    def __init__(self, *args, idurl=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if idurl:
+            for f in ('name', 'description', 'channel'):
+                self.fields.pop(f)
+
+
 class DevicesSerializer(TranslatableModelSerializer):
     space_project = SpaceProjectsSerializer(many = False, idurl = True)
     channels = ChannelsSerializer(many = True, idurl = True)
@@ -126,14 +141,6 @@ class CompactSessionsSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Session
         fields = ('time',)
-
-class ParametersSerializer(TranslatableModelSerializer):
-# TODO: fix the bug
-#    channel = HyperlinkedRelatedField(many = False, view_name = 'channel-detail', read_only = True)
-    channel = ChannelsSerializer()
-    class Meta:
-        fields = ('id', 'name', 'description', 'channel')
-        model = models.Parameter
 
 
 '''class QuicklookHyperlink(serializers.HyperlinkedRelatedField):

--- a/backend/promis/backend_api/serializer.py
+++ b/backend/promis/backend_api/serializer.py
@@ -57,8 +57,15 @@ class DevicesSerializer(TranslatableModelSerializer):
 
 
 class SessionsSerializer(serializers.ModelSerializer):
-    # TODO: wtf? /quicklook/ here
-    measurements = SwaggerHyperlinkedRelatedField(many = True, read_only = True, view_name = 'measurement-detail')
+    # TODO: STUB, see #196
+    #measurements = SwaggerHyperlinkedRelatedField(many = True, read_only = True, view_name = 'measurement-detail')
+    # cut from here:
+    measurements = SerializerMethodField()
+    def get_measurements(self, obj):
+        return (self.context['request'].build_absolute_uri('/api/measurements/' + str(m.id))
+                    for m in models.Measurement.objects.filter(session = obj))
+    # to here ^
+
     space_project = SwaggerHyperlinkedRelatedField(many = False, read_only = True, view_name = 'space_project-detail')
 
     geo_line = serializers.SerializerMethodField()

--- a/backend/promis/backend_api/serializer.py
+++ b/backend/promis/backend_api/serializer.py
@@ -19,15 +19,6 @@ class LookupById:
     '''Shortcut to include extra_kwargs to every Meta class'''
     extra_kwargs = { 'url': { 'lookup_field': 'id' } }
 
-# TODO: STUB, please implement a fitting serializer in Swagger so we can just SwaggerHyperlinkedRelatedField all over
-def _remove_extra_fields(obj, inline):
-    print("in extra fields")
-    if not inline:
-        fields = tuple(obj.fields.keys())
-        print(fields)
-        for f in fields:
-            if f not in ('id', 'url'):
-                obj.fields.pop(f)
 
 class SpaceProjectsSerializer(HyperlinkedTranslatableModelSerializer):
     timelapse = serializers.SerializerMethodField()
@@ -41,48 +32,28 @@ class SpaceProjectsSerializer(HyperlinkedTranslatableModelSerializer):
         model = models.Space_project
         fields = ('id', 'url', 'name', 'description', 'timelapse')
 
-    # TODO: STUB
-    def __init__(self, *args, inline = True, **kwargs):
-        super().__init__(*args, **kwargs)
-        _remove_extra_fields(self, inline)
-
 
 class ChannelsSerializer(HyperlinkedTranslatableModelSerializer):
     class Meta(LookupById):
         fields = ('id', 'url', 'name', 'description')
         model = models.Channel
 
-    # TODO: STUB
-    def __init__(self, *args, inline = True, **kwargs):
-        super().__init__(*args, **kwargs)
-        _remove_extra_fields(self, inline)
-
 
 class ParametersSerializer(HyperlinkedTranslatableModelSerializer):
-    channel = ChannelsSerializer(inline = False)
+    channel = SwaggerHyperlinkedRelatedField(many = False, read_only = True, view_name = 'channel-detail')
 
     class Meta(LookupById):
         fields = ('id', 'url', 'name', 'description', 'channel')
         model = models.Parameter
 
-    # TODO: STUB
-    def __init__(self, *args, inline = True, **kwargs):
-        super().__init__(*args, **kwargs)
-        _remove_extra_fields(self, inline)
-
 
 class DevicesSerializer(HyperlinkedTranslatableModelSerializer):
-    space_project = SpaceProjectsSerializer(many = False, inline = False)
-    channels = ChannelsSerializer(many = True, inline = False)
+    space_project = SwaggerHyperlinkedRelatedField(many = False, read_only = True, view_name = 'space_project-detail')
+    channels = SwaggerHyperlinkedRelatedField(many = True, read_only = True, view_name = 'channel-detail')
 
     class Meta(LookupById):
         model = models.Device
         fields = ('id', 'url', 'name', 'description', 'space_project', 'channels')
-
-    # TODO: STUB
-    def __init__(self, *args, inline = True, **kwargs):
-        super().__init__(*args, **kwargs)
-        _remove_extra_fields(self, inline)
 
 
 class SessionsSerializer(serializers.ModelSerializer):

--- a/backend/promis/backend_api/urls.py
+++ b/backend/promis/backend_api/urls.py
@@ -15,25 +15,8 @@ docrout = SimpleRouter()
 docrout.register(r'api/quicklook', views.QuicklookView)
 docrout.register(r'api/download', views.DownloadData)
 
-'''
-#== db view ==
-#TODO: This is used only for debugging, and should be removed
-#TODO: Remove it
-
-dbview = SimpleRouter()
-dbview.register(r'functions', views.FunctionsView)
-dbview.register(r'documents', views.DocumentsView)
-dbview.register(r'parameters', views.ParametersView)
-
-#=============
-'''
 
 urlpatterns =  router.urls + userreg.urls + [
     url('^api-auth/', include('rest_framework.urls', namespace = 'rest_framework')),
     url(r'^user/update/$', views.UserUpdate),
     ] + docrout.urls 
-    
-
-# + dbview.urls
-
-#print(urlpatterns)

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -59,14 +59,20 @@ class ProjectsView(PromisViewSet):
     queryset = models.Space_project.objects.all()
     serializer_class = serializer.SpaceProjectsSerializer
 
+class ChannelsView(PromisViewSet):
+    queryset = models.Channel.objects.all()
+    serializer_class = serializer.ChannelsSerializer
+
+class ParametersView(PromisViewSet):
+    queryset = models.Parameter.objects.all()
+    serializer_class = serializer.ParametersSerializer
+    filter_fields = ('channel',)
+
 class DevicesView(PromisViewSet):
     queryset = models.Device.objects.all()
     serializer_class = serializer.DevicesSerializer
     filter_fields = ('space_project',)
 
-class ChannelsView(PromisViewSet):
-    queryset = models.Channel.objects.all()
-    serializer_class = serializer.ChannelsSerializer
 
 class SessionsView(viewsets.ReadOnlyModelViewSet):
     queryset = models.Session.objects.all()
@@ -121,12 +127,7 @@ class SessionsView(viewsets.ReadOnlyModelViewSet):
 
         return queryset
 
-class ParametersView(viewsets.ReadOnlyModelViewSet):
-    queryset = models.Parameter.objects.all()
-    serializer_class = serializer.ParametersSerializer
-    filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('channel',)
-    permission_classes = (AllowAny,)
+
 
 class MeasurementsView(viewsets.ReadOnlyModelViewSet):
     queryset = models.Measurement.objects.all()

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -26,10 +26,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.exceptions import NotAuthenticated, NotFound, MethodNotAllowed
 
-# TODO: also used by orbit.py, maybe make util.time
-import datetime, pytz
-def maketime(u):
-    return datetime.datetime.fromtimestamp(u, tz=pytz.utc)
+import util.unix_time
 
 import datetime
 from rest_framework.decorators import permission_classes
@@ -53,7 +50,7 @@ class SessionFilter(django_filters.rest_framework.FilterSet):
     def unix_time_filter(self, queryset, name, value):
         # Composition of the queryset.filter argument depending on which field was used
         filter_actions = { 'time_begin': 'time_begin__gte', 'time_end': 'time_end__lte' }
-        return queryset.filter(**{ filter_actions[name]: maketime(value) })
+        return queryset.filter(**{ filter_actions[name]: util.unix_time.maketime(value) })
 
 
     class Meta:

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -51,6 +51,7 @@ class MeasurementsFilter(django_filters.rest_framework.FilterSet):
 class ProjectsView(viewsets.ReadOnlyModelViewSet):
     queryset = models.Space_project.objects.all()
     serializer_class = serializer.SpaceProjectsSerializer
+    lookup_field = 'id'
     permission_classes = (AllowAny,)
 
 class DevicesView(viewsets.ReadOnlyModelViewSet):

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -30,6 +30,13 @@ from rest_framework.exceptions import NotAuthenticated, NotFound, MethodNotAllow
 import datetime
 from rest_framework.decorators import permission_classes
 
+class PromisViewSet(viewsets.ReadOnlyModelViewSet):
+    '''Collects most commonly used View stuff'''
+    lookup_field = 'id'
+    permission_classes = (AllowAny,)
+    # TODO: Is it okay to put it here even for classes that don't need it?
+    filter_backends = (DjangoFilterBackend,)
+
 class SessionFilter(django_filters.rest_framework.FilterSet):
     time_begin = django_filters.IsoDateTimeFilter(lookup_expr='gte')
     time_end = django_filters.IsoDateTimeFilter(lookup_expr='lte')
@@ -48,23 +55,18 @@ class MeasurementsFilter(django_filters.rest_framework.FilterSet):
         model = models.Measurement
         fields = ['session', 'parameter']
 
-class ProjectsView(viewsets.ReadOnlyModelViewSet):
+class ProjectsView(PromisViewSet):
     queryset = models.Space_project.objects.all()
     serializer_class = serializer.SpaceProjectsSerializer
-    lookup_field = 'id'
-    permission_classes = (AllowAny,)
 
-class DevicesView(viewsets.ReadOnlyModelViewSet):
+class DevicesView(PromisViewSet):
     queryset = models.Device.objects.all()
     serializer_class = serializer.DevicesSerializer
-    filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('satellite',)
-    permission_classes = (AllowAny,)
+    filter_fields = ('space_project',)
 
-class ChannelsView(viewsets.ReadOnlyModelViewSet):
+class ChannelsView(PromisViewSet):
     queryset = models.Channel.objects.all()
     serializer_class = serializer.ChannelsSerializer
-    permission_classes = (PromisPermission,)
 
 class SessionsView(viewsets.ReadOnlyModelViewSet):
     queryset = models.Session.objects.all()

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -74,13 +74,11 @@ class DevicesView(PromisViewSet):
     filter_fields = ('space_project',)
 
 
-class SessionsView(viewsets.ReadOnlyModelViewSet):
+class SessionsView(PromisViewSet):
     queryset = models.Session.objects.all()
     serializer_class = serializer.SessionsSerializer
-    filter_backends = (DjangoFilterBackend,)
     filter_class = SessionFilter
     pagination_class = LimitOffsetPagination
-    permission_classes = (AllowAny,)
 
     def get_queryset(self):
 
@@ -129,32 +127,11 @@ class SessionsView(viewsets.ReadOnlyModelViewSet):
 
 
 
-class MeasurementsView(viewsets.ReadOnlyModelViewSet):
+class MeasurementsView(PromisViewSet):
     queryset = models.Measurement.objects.all()
     serializer_class = serializer.MeasurementsSerializer
-    permission_classes = (AllowAny,)
     filter_class = MeasurementsFilter
-    filter_backends = (DjangoFilterBackend,)
 
-
-'''
-#TODO: This is used only for debugging, and should be removed
-#======== Added to view db contents. Remove it: ======
-
-class DocumentsView(viewsets.ReadOnlyModelViewSet):
-    queryset = models.Document.objects.all()
-    serializer_class = serializer.DocumentsSerializer
-
-class FunctionsView(viewsets.ReadOnlyModelViewSet):
-    queryset = models.Function.objects.all()
-    serializer_class = serializer.FunctionsSerializer
-
-class ParameterssView(viewsets.ReadOnlyModelViewSet):
-    queryset = models.Parameter.objects.all()
-    serializer_class = serializer.ParametersSerializer
-
-#=====================================================
-'''
 
 class QuicklookView(RetrieveModelMixin, viewsets.GenericViewSet):
     def _quicklook(self, obj, src_name, src_serializer):
@@ -218,10 +195,6 @@ class QuicklookView(RetrieveModelMixin, viewsets.GenericViewSet):
     permission_classes = (AllowAny,)
     serializer_class = serializer.MeasurementsSerializer
 
-class DownloadView(viewsets.ReadOnlyModelViewSet):
-    queryset = models.Measurement.objects.all()
-    permission_classes = (AllowAny,)
-    serializer_class = serializer.DownloadViewSerializer
 
 # TODO: make a common base class for this and QuicklookView
 from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer

--- a/backend/promis/functions/potential.py
+++ b/backend/promis/functions/potential.py
@@ -22,7 +22,7 @@
 # TODO: maintain 1 continuous FTP object
 
 from django.contrib.gis.geos import LineString
-import util.orbit, util.ftp, util.parsers, util.stats, util.export
+import util.orbit, util.ftp, util.parsers, util.stats, util.export, util.unix_time
 import backend_api.models as model
 
 # TODO: integrate into ftp.py somehow
@@ -133,8 +133,8 @@ def data_func(satellite_object):
                                 line_gen = ( (y.lon, y.lat, y.alt) for _, y, _ in util.orbit.generate_orbit(orbit, time_start, time_end) )
                                 # Converting time to python objects for convenience
                                 # This is the point where onboard time gets converted to the UTC
-                                time_start = util.orbit.maketime(time_start)
-                                time_end = util.orbit.maketime(time_end)
+                                time_start = util.unix_time.maketime(time_start)
+                                time_end = util.unix_time.maketime(time_end)
                                 time_dur = time_end - time_start
                                 print("\tSession: [ %s, %s ] (%s)." % (time_start.isoformat(), time_end.isoformat(), str(time_dur)) )
 

--- a/backend/promis/functions/test_set.py
+++ b/backend/promis/functions/test_set.py
@@ -19,7 +19,7 @@
 # permissions and limitations under the Licence.
 #
 
-import util.ftp, util.parsers, util.orbit
+import util.ftp, util.parsers, util.unix_time
 from django.contrib.gis.geos import LineString
 import backend_api.models as model
 
@@ -34,8 +34,8 @@ def general_fetch(path, satellite_object, add_measurement=False):
             ftp.cwd(sess_name)
             with ftp.xopen("orbit.csv") as fp:
                 line_gen = [ pt for pt in util.parsers.csv(fp) ]
-                time_start = util.orbit.maketime(timemark)
-                time_end = util.orbit.maketime(timemark + len(line_gen)) # Orbit points are 1 per second
+                time_start = util.unix_time.maketime(timemark)
+                time_end = util.unix_time.maketime(timemark + len(line_gen)) # Orbit points are 1 per second
                 time_dur = time_end - time_start
                 # TODO: maybe let the caller print these diagnostics?
                 print("\tSession: [ %s, %s ] (%s)." % (time_start.isoformat(), time_end.isoformat(), str(time_dur)) )

--- a/backend/promis/util/orbit.py
+++ b/backend/promis/util/orbit.py
@@ -23,13 +23,8 @@ import math
 import collections
 import operator
 import util.cubefit
-import datetime, pytz
 
 _earth_radius = 6371 # km
-
-# TODO: onboard time shift
-def maketime(u):
-    return datetime.datetime.fromtimestamp(u, tz=pytz.utc)
 
 def sign(x):
     """Returns 1 for non-negative arguments and -1 otherwise."""

--- a/backend/promis/util/parsers.py
+++ b/backend/promis/util/parsers.py
@@ -22,18 +22,7 @@
 
 import re, struct
 import util.orbit
-import datetime
-import pytz
-
-def datetime_to_utc(x):
-    # Add the 00:00 time if we only got a date
-    if type(x) is datetime.date:
-        x = datetime.datetime.combine(x, datetime.datetime.min.time())
-    return int(x.replace(tzinfo=pytz.timezone("UTC")).timestamp())
-
-def str_to_utc(x):
-    time_fmt = "%Y{0}%m{0}%d %H:%M:%S".format(x[4])
-    return datetime_to_utc(datetime.datetime.strptime(x, time_fmt))
+import util.unix_time
 
 # TODO: cull out those which have standard parsers (CSV?)
 # TODO: replace ValueErrors with meaningful exception classes when integrating
@@ -90,7 +79,7 @@ def telemetry(fp):
             m = re.search("^[0-9]* ([0-9.-]*) (2.*)", ln)
             if m:
                 # Yielding a nested tuple e.g. ( "RX", (1, 432.0) ), will be converted to dict
-                yield ( sect, (str_to_utc(m.group(2)), float(m.group(1))) )
+                yield ( sect, (util.unix_time.str_to_utc(m.group(2)), float(m.group(1))) )
             else:
                 raise ValueError("Input inconsistency detected")
 
@@ -150,7 +139,7 @@ def sets(fp, keys=None):
         keys_found.add(key)
 
         # Yield the data
-        yield key, int(value) if key != "utc" else str_to_utc(value)
+        yield key, int(value) if key != "utc" else util.unix_time.str_to_utc(value)
 
         # Reduce the counter of keys to look for and break if necessary
         if keys_left > 0:

--- a/backend/promis/util/parsers.py
+++ b/backend/promis/util/parsers.py
@@ -25,11 +25,15 @@ import util.orbit
 import datetime
 import pytz
 
+def datetime_to_utc(x):
+    # Add the 00:00 time if we only got a date
+    if type(x) is datetime.date:
+        x = datetime.datetime.combine(x, datetime.datetime.min.time())
+    return int(x.replace(tzinfo=pytz.timezone("UTC")).timestamp())
+
 def str_to_utc(x):
     time_fmt = "%Y{0}%m{0}%d %H:%M:%S".format(x[4])
-    ts = datetime.datetime.strptime(x, time_fmt)
-    ts = ts.replace(tzinfo=pytz.timezone("UTC")).timestamp()
-    return int(ts)
+    return datetime_to_utc(datetime.datetime.strptime(x, time_fmt))
 
 # TODO: cull out those which have standard parsers (CSV?)
 # TODO: replace ValueErrors with meaningful exception classes when integrating

--- a/backend/promis/util/unix_time.py
+++ b/backend/promis/util/unix_time.py
@@ -1,0 +1,37 @@
+#
+# Copyright 2016 Space Research Institute of NASU and SSAU (Ukraine)
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they
+# will be approved by the European Commission - subsequent
+# versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the
+# Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# Unless required by applicable law or agreed to in
+# writing, software distributed under the Licence is
+# distributed on an "AS IS" basis,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied.
+# See the Licence for the specific language governing
+# permissions and limitations under the Licence.
+#
+"""Useful utilities for converting UNIX timestamps back and forth"""
+
+import datetime
+import pytz
+
+def datetime_to_utc(x):
+    # Add the 00:00 time if we only got a date
+    if type(x) is datetime.date:
+        x = datetime.datetime.combine(x, datetime.datetime.min.time())
+    return int(x.replace(tzinfo=pytz.timezone("UTC")).timestamp())
+
+def str_to_utc(x):
+    time_fmt = "%Y{0}%m{0}%d %H:%M:%S".format(x[4])
+    return datetime_to_utc(datetime.datetime.strptime(x, time_fmt))
+
+def maketime(u):
+    return datetime.datetime.fromtimestamp(u, tz=pytz.utc)

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -558,12 +558,14 @@ definitions:
       #- $ref: '#/definitions/NameDesc'
       #- properties:
       space_project:
-        $ref: '#/definitions/IdURL'
+        type: string
+        description: API Link to the related Space Project
       channels:
         type: array
         description: Channels the device provides
         items:
-          $ref: '#/definitions/IdURL'
+          type: string
+          description: API Link to the channel provided
 
   Channel:
     type: object
@@ -609,7 +611,8 @@ definitions:
             #allOf:
               #- description: Channel the parameter depends on
               #- $ref: '#/definitions/IdURL'
-        $ref: '#/definitions/IdURL'
+        type: string
+        description: API Link to the related channel
 
   Session:
     type: object
@@ -640,7 +643,8 @@ definitions:
           #timelapse:
             #$ref: '#/definitions/Time'
       space_project:
-        $ref: '#/definitions/IdURL'
+        type: string
+        description: API Link to the related Space Project
       orbit:
         type: number
         description: Orbit representation
@@ -650,7 +654,8 @@ definitions:
         type: array # api links to measurement instances
         description: Available measurements for this session
         items:
-          $ref: '#/definitions/IdURL'
+          type: string
+          description: API Link to the measurement during the session
       timelapse:
         $ref: '#/definitions/Time'
 
@@ -694,30 +699,33 @@ definitions:
             #type: string
             #description: URL to parameter data download
       session:
-       $ref: '#/definitions/IdURL'
+        type: string
+        description: API Link to the related session
       channel:
-       $ref: '#/definitions/IdURL'
+        type: string
+        description: API Link to the measured channel
       parameter:
-       $ref: '#/definitions/IdURL'
+        type: string
+        description: API Link to the measured parameter
       freq:
-       type: number
-       description: Sampling frequency
+        type: number
+        description: Sampling frequency
       min_freq:
-       type: number
+        type: number
       max_freq:
-       type: number
+        type: number
       channel_quicklook:
-       type: string
-       description: URL to channel quicklook
+        type: string
+        description: URL to channel quicklook
       channel_download:
-       type: string
-       description: URL to channel data download
+        type: string
+        description: URL to channel data download
       parameter_quicklook:
-       type: string
-       description: URL to parameter quicklook
+        type: string
+        description: URL to parameter quicklook
       parameter_download:
-       type: string
-       description: URL to parameter data download
+        type: string
+        description: URL to parameter data download
 
   Quicklook:
     type: object

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -217,7 +217,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/IdURL'
+              $ref: '#/definitions/SessionCompact'
         default:
           description: Unexpected error
           schema:

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -659,6 +659,31 @@ definitions:
       timelapse:
         $ref: '#/definitions/Time'
 
+  # merge with Session using allOf when #193 is resolved
+  SessionCompact:
+    type: object
+    properties:
+      id:
+        type: number
+        description: Unique numberic identifier
+      url:
+        type: string
+        description: URL location within API
+      space_project:
+        type: string
+        description: API Link to the related Space Project
+      orbit:
+        type: number
+        description: Orbit representation
+      measurements:
+        type: array # api links to measurement instances
+        description: Available measurements for this session
+        items:
+          type: string
+          description: API Link to the measurement during the session
+      timelapse:
+        $ref: '#/definitions/Time'
+
 
   Measurement:
     type: object

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -527,7 +527,7 @@ definitions:
       name:
         type: string
         description: Short name
-      desc:
+      description:
         type: string
         description: In-depth description
     #allOf:
@@ -550,13 +550,15 @@ definitions:
       name:
         type: string
         description: Short name
-      desc:
+      description:
         type: string
         description: In-depth description
     #allOf:
       #- $ref: '#/definitions/IdURL'
       #- $ref: '#/definitions/NameDesc'
       #- properties:
+      space_project:
+        $ref: '#/definitions/IdURL'
       channels:
         type: array
         description: Channels the device provides
@@ -576,7 +578,7 @@ definitions:
       name:
         type: string
         description: Short name
-      desc:
+      description:
         type: string
         description: In-depth description
     #allOf:
@@ -596,7 +598,7 @@ definitions:
       name:
         type: string
         description: Short name
-      desc:
+      description:
         type: string
         description: In-depth description
     #allOf:
@@ -637,9 +639,8 @@ definitions:
               #$ref: '#/definitions/IdURL'
           #timelapse:
             #$ref: '#/definitions/Time'
-      project:
-        type: integer
-        description: Related project ID
+      space_project:
+        $ref: '#/definitions/IdURL'
       orbit:
         type: number
         description: Orbit representation
@@ -798,7 +799,7 @@ definitions:
       name:
         type: string
         description: Short name
-      desc:
+      description:
         type: string
         description: In-depth description
 

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -732,12 +732,12 @@ definitions:
       parameter:
         type: string
         description: API Link to the measured parameter
-      freq:
+      sampling_frequency:
         type: number
         description: Sampling frequency
-      min_freq:
+      min_frequency:
         type: number
-      max_freq:
+      max_frequency:
         type: number
       channel_quicklook:
         type: string

--- a/test/data/test_set.json
+++ b/test/data/test_set.json
@@ -108,7 +108,7 @@
     "model": "backend_api.device",
     "pk": 42000,
     "fields": {
-        "satellite": 42001
+        "space_project": 42001
     }
 },
 {

--- a/test/tests_backend/test_auth.py
+++ b/test/tests_backend/test_auth.py
@@ -101,18 +101,18 @@ def test_level1_listing(connie):
 # TODO: generalise the code
 def test_level2_access(melanie):
     '''Check that a level2 user can see only parameter fields'''
-    r = melanie.get("/en/api/download/1")
+    r = melanie.get("/en/api/measurements/1")
     assert r.status_code == 200, "Invalid status code"
     json_data = r.json()
-    assert "channel_doc" not in json_data, "Can see channels"
-    assert "parameter_doc" in json_data, "Can't see parameters"
+    assert "channel_download" not in json_data, "Can see channels"
+    assert "parameter_download" in json_data, "Can't see parameters"
 
 def test_level1_access(connie):
     '''Check that a level1 user can see all fields'''
-    r = connie.get("/en/api/download/1")
+    r = connie.get("/en/api/measurements/1")
     assert r.status_code == 200, "Invalid status code"
     json_data = r.json()
-    assert "channel_doc" in json_data, "Can't see channels"
-    assert "parameter_doc" in json_data, "Can't see parameters"
+    assert "channel_download" in json_data, "Can't see channels"
+    assert "parameter_download" in json_data, "Can't see parameters"
 
 


### PR DESCRIPTION
- Sessions are now filtered by UNIX time;
- Most entities now have an `url` field and relate to the dependants by URLs;
- Some fields renamed for consistency (more work is needed);
- Sessions in list query hide the orbit field;
- Some code cleanup, more will follow;
- Several improvements blocked at #196;
- Tests are broken before Quicklook/Download overhaul in next PR.

Please look at this and merge. kthxbye