### PR TITLE
Quicklook and Download cleanup

### DIFF
--- a/backend/promis/backend_api/fixtures/init_data.json
+++ b/backend/promis/backend_api/fixtures/init_data.json
@@ -153,6 +153,7 @@
     "model": "backend_api.channel",
     "pk": 1,
     "fields": {
+        "value": 1,
         "device": 1,
         "quicklook": null,
         "parser_func": null,
@@ -163,6 +164,7 @@
     "model": "backend_api.channel",
     "pk": 2,
     "fields": {
+        "value": 1,
         "device": 1,
         "quicklook": null,
         "parser_func": null,

--- a/backend/promis/backend_api/models.py
+++ b/backend/promis/backend_api/models.py
@@ -92,6 +92,7 @@ class Device(TranslatableModel):
         return self.name
 
 class Channel(TranslatableModel):
+    value = ForeignKey('Value')
     device = ForeignKey('Device', related_name = 'channels')  # TODO: <- do we need this?
     quicklook = ForeignKey('Function', related_name = 'ch_ql', blank=True, null=True)
     export = ForeignKey('Function', related_name = 'ch_ex', blank=True, null=True)

--- a/backend/promis/backend_api/serializer.py
+++ b/backend/promis/backend_api/serializer.py
@@ -171,7 +171,7 @@ class MeasurementsSerializer(serializers.ModelSerializer):
     #TODO: SPIKE: remove below hard code and replace to related view path.
     def construct_data_url(self, obj, source, action):
         id = getattr(obj, source + "_doc").id
-        return self.context['request'].build_absolute_uri('/api/%s/%d/%s' % (action, id, source))
+        return self.context['request'].build_absolute_uri('/api/download/%d/%s?source=%s' % (id, action, source))
 
     def get_channel_quicklook(self, obj):
         return self.construct_data_url(obj, "channel", "quicklook")
@@ -189,6 +189,8 @@ class MeasurementsSerializer(serializers.ModelSerializer):
         user = self.context['request'].user
         if not (helpers.UserInGroup(user, 'level1') or helpers.IsSuperUser(user)):
             self.fields.pop('channel_download')
+        if not user.is_authenticated():
+            self.fields.pop('parameter_download')
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/promis/backend_api/urls.py
+++ b/backend/promis/backend_api/urls.py
@@ -20,5 +20,3 @@ urlpatterns =  router.urls + userreg.urls + [
     url(r'^user/update/$', views.UserUpdate),
     ] + docrout.urls
 
-for i in urlpatterns:
-    print(i)

--- a/backend/promis/backend_api/urls.py
+++ b/backend/promis/backend_api/urls.py
@@ -12,6 +12,7 @@ userreg.register(r'user', views.UserViewSet)
 
 
 docrout = SimpleRouter()
+# TODO: maaaybe we go as far as /measurements/<id>/quicklook ?
 docrout.register(r'api/download', views.DownloadView)
 
 

--- a/backend/promis/backend_api/urls.py
+++ b/backend/promis/backend_api/urls.py
@@ -12,11 +12,13 @@ userreg.register(r'user', views.UserViewSet)
 
 
 docrout = SimpleRouter()
-docrout.register(r'api/quicklook', views.QuicklookView)
-docrout.register(r'api/download', views.DownloadData)
+docrout.register(r'api/download', views.DownloadView)
 
 
 urlpatterns =  router.urls + userreg.urls + [
     url('^api-auth/', include('rest_framework.urls', namespace = 'rest_framework')),
     url(r'^user/update/$', views.UserUpdate),
-    ] + docrout.urls 
+    ] + docrout.urls
+
+for i in urlpatterns:
+    print(i)

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -187,7 +187,7 @@ class DownloadView(viewsets.GenericViewSet):
         # if user_not_authenticated and self.points > max_points_for_this_json * some_coeff:
         #   raise NotAuthenticated
 
-        self.serializer_class = serializer.MeasurementsSerializer
+        self.serializer_class = serializer.QuicklookSerializer
         return self.create_data()
 
     @detail_route(permission_classes = (AllowAny,), # TODO: other permission class

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from rest_framework.views import APIView
-from rest_framework.generics import  GenericAPIView, ListAPIView
+from rest_framework.generics import  GenericAPIView, ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework import viewsets
 from rest_framework import status
@@ -25,6 +25,7 @@ from django.contrib.auth import get_user_model
 
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.exceptions import NotAuthenticated, NotFound, MethodNotAllowed
+from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
 
 import util.unix_time
 
@@ -119,78 +120,88 @@ class SessionsView(PromisViewSet):
         return queryset
 
 
-
 class MeasurementsView(PromisViewSet):
     queryset = models.Measurement.objects.all()
     serializer_class = serializer.MeasurementsSerializer
     filter_class = MeasurementsFilter
 
 
-class QuicklookView(RetrieveModelMixin, viewsets.GenericViewSet):
-    def _quicklook(self, obj, src_name, src_serializer):
-        '''Generalized quicklook function'''
+class DownloadView(viewsets.GenericViewSet):
+    '''
+    Handles data downloads and quicklooks.
+
+    Data source defined by source request parameter
+    which can be either channel or parameter.
+
+    Operation is defined by the last path element
+    which can be either data or quicklook.
+
+    Data method takes a fmt parameter (shared with Django)
+    that determines the output format.
+
+    Quicklook method takes a points parameter which
+    determines the resolution of a quicklook.
+
+    Both accept time_start and time_end parameters in
+    UNIX seconds at UTC to specify data slicing.
+
+    Ideally we could support slicing by a polygon, but not now
+    '''
+    # TODO: seriously? Django displays a docstring?
+
+    # Basically what RetrieveModelMixin does, but without
+    # creating a separate "-detail" view
+    # TODO: when we fix swagger route generation this may be
+    # turned redundant by just inheriting the mixin
+    def create_data(self):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+
+    @detail_route(permission_classes = (AllowAny,))
+    def quicklook(self, request, id):
         # TODO: JSON/HTML-ify the responses here?
         # TODO: 422 instead of 404 for incorrect params?
         # TODO: most of the raises here are redundant and should be done
         # in validators.
-
-        # Determining the quicklook function
-        quicklook_fun = getattr(obj, src_name).quicklook
-
-        if not quicklook_fun:
-            raise MethodNotAllowed('< no quicklook defined >')
-
-        # TODO: many stubs here depend on the knowledge of the JSON structure
-        # which varies type to type. Making 100500 functions is unfeasible, so
-        # we might want to wrap this into classes with known interface and
-        # use JSON as pickle/unpickle medium or something. Postponed to post-alpha
-        # see and use #63 for more details.
+        # TODO: determine where exactly should the validation happen
 
         # Determining the quality of a quicklook
         try:
-            npoints = int(self.request.query_params['points'])
+            self.points = int(self.request.query_params['points'])
         except KeyError:
             # TODO: configurable default or per-type setting here
-            npoints = 200
+            self.points = 200
         except ValueError:
             raise NotFound("Amount of points is not a number")
 
         # Various checks on the number received
-        if npoints <= 0:
+        if self.points <= 0:
             raise NotFound("Non-positive amount of points requested")
 
         # TODO: STUB: determine upper cap, that depends on the type in question
-        # if npoints > max_points_for_this_json:
+        # if self.points > max_points_for_this_json:
         #   raise NotFound("Too much points requested")
 
         # TODO: STUB: determine if user is not authenticated, lower the cap for them
-        # if user_not_authenticated and npoints > max_points_for_this_json * some_coeff:
+        # if user_not_authenticated and self.points > max_points_for_this_json * some_coeff:
         #   raise NotAuthenticated
 
-        ser = serializer.QuickLookSerializer(obj, context = { 'func': quicklook_fun,
-                                                              'kwargs': { 'npoints': npoints },
-                                                              'serializer': src_serializer,
-                                                              'source': src_name,
-                                                              'need_geo_line': False } )
-        return Response(ser.data)
+        self.serializer_class = serializer.MeasurementsSerializer
+        return self.create_data()
 
-    @detail_route(permission_classes = [AllowAny,])
-    def channel(self, request, id):
-        obj = self.queryset.get(pk = id)
-        return self._quicklook(obj, "channel", serializer.ChannelsSerializer)
+    @detail_route(permission_classes = (AllowAny,), # TODO: other permission class
+                  renderer_classes = (BrowsableAPIRenderer, JSONRenderer, serializer.PlainTextRenderer))
+    def data(self, request, id):
+        self.serializer_class = serializer.MeasurementsSerializer
+        return self.create_data()
 
-    @detail_route(permission_classes = [AllowAny,])
-    def parameter(self, request, id):
-        obj = self.queryset.get(pk = id)
-        return self._quicklook(obj, "parameter", serializer.ParametersSerializer)
-
+    lookup_field = 'id'
     queryset = models.Measurement.objects.all()
-    permission_classes = (AllowAny,)
-    serializer_class = serializer.MeasurementsSerializer
 
 
 # TODO: make a common base class for this and QuicklookView
-from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+
 class DownloadData(RetrieveModelMixin, viewsets.GenericViewSet):
     renderer_classes = (BrowsableAPIRenderer, JSONRenderer, serializer.PlainTextRenderer)
 

--- a/backend/promis/objectmodel/base.py
+++ b/backend/promis/objectmodel/base.py
@@ -49,6 +49,7 @@ class AbstractTimeSeries:
         return self[start:end]
 
     def quicklook(self):
+        pass
 
 
 

--- a/backend/promis/objectmodel/base.py
+++ b/backend/promis/objectmodel/base.py
@@ -1,0 +1,55 @@
+#
+# Copyright 2016 Space Research Institute of NASU and SSAU (Ukraine)
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they
+# will be approved by the European Commission - subsequent
+# versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the
+# Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# Unless required by applicable law or agreed to in
+# writing, software distributed under the Licence is
+# distributed on an "AS IS" basis,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied.
+# See the Licence for the specific language governing
+# permissions and limitations under the Licence.
+#
+"""Base functionality for object-oriented data model"""
+
+class AbstractTimeSeries:
+    """
+    Derived classes are expected to implement:
+    - self.__len__          -- for sample size
+    - self.__getitem___     -- for data access
+    - self.data_start       -- UNIX timestamp
+    - self.frequency        -- sampling frequency
+    """
+
+    def timeslice(self, start, end):
+        """
+        Yields data between start and end inclusively.
+        start and end are UNIX seconds at UTC.
+        """
+        data_end = self.data_start + len(self) // self.frequency
+        if start < self.data_start or end > data_end:
+            raise IndexError
+
+        # Shifting the bounds
+        start -= self.data_start
+        end -= self.data_start
+
+        # Converting time to samples
+        start *= self.frequency
+        end *= self.frequency
+
+        return self[start:end]
+
+    def quicklook(self):
+
+
+
+

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -387,130 +387,87 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  # TODO: here and below, add /channel and /parameter paths
+  # TODO: crude implementation please refine
   # TODO: reuse parameters across several paths
-  # Quicklook
-  /quicklook/{id}/{source}:
-    x-swagger-object-key: id
-    x-swagger-router-view: QuicklookView
-    get:
-      operationId: Quicklook
-      summary: Get a quicklook of data
-      tags:
-        - Measurements
-      description: |
-        This endpoint allows to get a quicklook of certain data measurement.
-      parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Unique numerical identifier
-        # $ref: '#/parameters/Id' # #193
-        - name: source
-          in: path
-          type: string
-          description: Where to take the data from
-          required: true
-          enum:
-            - parameter
-            - channel
-        #- $ref: '#/parameters/Source'
-        #- $ref: '#/parameters/FromTime'
-        #- $ref: '#/parameters/ToTime'
-        #- $ref: '#/parameters/Polygon'
-        - name: fromtime
-          in: query
-          description: From time, UNIX timestamp at UTC
-          type: integer
-        - name: totime
-          in: query
-          description: To time, UNIX timestamp at UTC
-          type: integer
-        # TODO: in future release
-        - name: polygon
-          description: WKT polygon with desired search area
-          in: query
-          type: string
-        - name: points
-          in: query
-          type: integer
-          required: false
-          description: Amount of data points to show on the quicklook.
-      responses:
-        200:
-          description: Quicklook data
-          schema:
-            $ref: '#/definitions/Quicklook'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
-  # Data download
-  /download/{id}/{source}:
-    x-swagger-object-key: id
-    x-swagger-router-view: DownloadView
-    get:
-      operationId: Download
-      summary: Download data
-      tags:
-        - Measurements
-      description: |
-        This endpoint allows to get a quicklook of certain data measurement.
-      parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-          description: Unique numerical identifier
-        # $ref: '#/parameters/Id' # #193
-        - name: source
-          in: path
-          type: string
-          description: Where to take the data from
-          required: true
-          enum:
-            - parameter
-            - channel
-        #- $ref: '#/parameters/Source'
-        #- $ref: '#/parameters/FromTime'
-        #- $ref: '#/parameters/ToTime'
-        #- $ref: '#/parameters/Polygon'
-        - name: fromtime
-          in: query
-          description: From time, UNIX timestamp at UTC
-          type: integer
-        - name: totime
-          in: query
-          description: To time, UNIX timestamp at UTC
-          type: integer
-        # TODO: in future release
-        - name: polygon
-          description: WKT polygon with desired search area
-          in: query
-          type: string
-        # TODO: - required not working - put it on the deeper links
-        - name: fmt
-          in: query
-          type: string
-          required: false
-          description: Format name to download data in.
-          default: json
-          enum:
-            - json
-            - ascii
-            - csv
-            - netcdf
-      responses:
-        200:
-          description: Raw data
-          schema:
-            $ref: '#/definitions/RawData'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
+  # TODO: re-activate, this doesn't play well with @detail_route
+  #/download/{id}/{method}:
+    #x-swagger-object-key: id
+    #x-swagger-router-view: DownloadView
+    #get:
+      #operationId: Download STUB
+      #summary: Downloads and quicklooks
+      #tags:
+        #- Measurements
+      #description: |
+        #Please ignore the description for now, needs multiaction support
+      #parameters:
+        #- name: id
+          #in: path
+          #type: integer
+          #required: true
+          #description: Unique numerical identifier
+        #- name: method
+          #in: path
+          #type: string
+          #required: true
+          #description: Operation to do on the data
+          #enum:
+            #- quicklook
+            #- data
+        #- name: source
+          #in: query
+          #type: string
+          #description: Where to take the data from
+          #required: false
+          #default: parameter
+      ## TODO: ErintLabs/django-openapi-gen#17
+       ##   enum:
+       ##    - parameter
+       ##    - channel
+        #- name: fromtime
+          #in: query
+          #description: From time, UNIX timestamp at UTC
+          #type: integer
+        #- name: totime
+          #in: query
+          #description: To time, UNIX timestamp at UTC
+          #type: integer
+        ## TODO: in future release
+        #- name: polygon
+          #description: WKT polygon with desired search area
+          #in: query
+          #type: string
+        #- name: points
+          #in: query
+          #type: integer
+          #required: false
+          #description: Amount of data points to show (only quicklook)
+        #- name: fmt
+          #in: query
+          #type: string
+          #required: false
+          #description: Format name to download data in (only data)
+          #default: json
+      ## TODO: ErintLabs/django-openapi-gen#17
+       ##   enum:
+       ##     - json
+       ##     - ascii
+       ##     - csv
+       ##     - netcdf
+        ##- $ref: '#/parameters/Source'
+        ##- $ref: '#/parameters/FromTime'
+        ##- $ref: '#/parameters/ToTime'
+        ##- $ref: '#/parameters/Polygon'
+      #responses:
+        #200:
+          #description: Raw data
+          #schema:
+            ## TODO: pull the quicklook in here
+            #$ref: '#/definitions/RawData'
+        #default:
+          #description: Unexpected error
+          #schema:
+            #$ref: '#/definitions/Error'
 
 # return objects
 definitions:

--- a/test/data/test_set.json
+++ b/test/data/test_set.json
@@ -135,6 +135,7 @@
     "model": "backend_api.channel",
     "pk": 42000,
     "fields": {
+        "value": 42000,
         "device": 42000,
         "quicklook": null,
         "parser_func": null

--- a/test/tests_backend/test_backend_bugs.py
+++ b/test/tests_backend/test_backend_bugs.py
@@ -36,15 +36,17 @@ def test_per_project_sessions(connie):
 
 def test_super_user_access_level1(superuser):
     '''IonosatMicro/promis-backend#75'''
-    r = superuser.get("/en/api/download/1")
+    r = superuser.get("/en/api/measurements/1")
     assert r.status_code == 200, "Invalid status code"
     json_data = r.json()
-    assert "channel_doc" in json_data, "Can't see channels"
-    assert "parameter_doc" in json_data, "Can't see parameters"
+    assert "channel_quicklook" in json_data, "Can't see channels quicklook"
+    assert "parameter_quicklook" in json_data, "Can't see parameters quicklook"
+    assert "channel_download" in json_data, "Can't see channels"
+    assert "parameter_download" in json_data, "Can't see parameters"
 
 def test_unauth_access(session):
     '''IonosatMicro/promis-backend#78'''
-    r = session.get("/en/api/download/1")
+    r = session.get("/en/api/measurements/1")
     assert r.status_code != 500, "Invalid status code"
     # TODO: this doesn't perfectly verify the described behaviour, but I assume the root cause is the same
 
@@ -85,4 +87,4 @@ def test_per_project_sessions(user, space_project_id, user_name):
     assert "count" in json_data, "Malformed JSON received"
     assert json_data["count"] > 0, "Can't see any session"
     assert "results" in json_data and len(json_data["results"]) > 0, "Malformed JSON received"
-    assert json_data["results"][0]["space_project"] == space_project_id
+    assert "api/projects/%d" % space_project_id in json_data["results"][0]["space_project"]


### PR DESCRIPTION
Intermediate version, requesting a PR so that UI code won't be blocked.
- Quicklook and JSON data download now 
- Relevant YML part is _disabled_ for now (see #196)
- OOP mechanics for the data model not implemented yet, but things will be as they are from the API perspective (hopefully)
- Tests should be green now

Please *do not* delete the branch afterwards, I still have work to do here.