### PR TITLE
Quicklook ui update

### DIFF
--- a/frontend/app/components/Quicklook.js
+++ b/frontend/app/components/Quicklook.js
@@ -18,7 +18,7 @@ export default class Quicklook extends Component {
         this.formatData = this.formatData.bind(this);
         this.makeFilename = this.makeFilename.bind(this);
         this.makeWatermark = this.makeWatermark.bind(this);
-        this.data = this.formatData(this.props.data);
+        this.data = this.formatData(this.props.data, this.props.time);
     }
 
     componentDidUpdate() {
@@ -88,7 +88,7 @@ export default class Quicklook extends Component {
         } else window.alert('Quicklook is not completely loaded yet!');
     }
 
-    formatData(data) {
+    formatData(data, time) {
         var dataObj = [
         {
             name: 'series3',
@@ -99,8 +99,13 @@ export default class Quicklook extends Component {
         var formatted = new Array();
 
         if(Array.isArray(data)) {
+            /* Adjusting the X axis to the actual duration */
+            /* TODO: do we include the last second? */
+            var data_duration = time.end - time.start + 1;
+            var sec_per_sample = data_duration / data.length;
+
             data.map(function(item, index) {
-                formatted.push({ x: index, y: item });
+                formatted.push({ x: sec_per_sample * index, y: item });
             })
         } else formatted = [{ x: 0, y: 20 }, { x: 1, y: 30 }, { x: 2, y: 10 }, { x: 3, y: 5 }, { x: 4, y: 8 }, { x: 5, y: 15 }, { x: 6, y: 10 }];
 
@@ -111,7 +116,7 @@ export default class Quicklook extends Component {
 
     render() {
         return (
-            <Modal show = {this.props.show} title = 'Quicklook' onClose = {this.props.onClose}>
+            <Modal show = {this.props.show} title = {this.props.timelapse} onClose = {this.props.onClose}>
                 <LineChart
                     ref = { function(node) { this.el = node; }.bind(this) }
                     legend = {false}
@@ -149,6 +154,6 @@ Quicklook.defaultProps = {
     graphHeight: 480,
     watermarkText: 'https://promis.ikd.kiev.ua',
     title: 'Quicklook description',
-    xlabel: 'x axis label',
+    xlabel: 'time (sec)', /* TODO: localisation */
     ylabel: 'y axis label'
 }

--- a/frontend/app/components/SearchResults.js
+++ b/frontend/app/components/SearchResults.js
@@ -3,6 +3,11 @@ import { Form, Button, Glyphicon } from 'react-bootstrap';
 import Tooltip from './Tooltip';
 import Quicklook from './Quicklook';
 
+/* TODO: do you need this shared anywhere? */
+function UnixToISO(unix_ts) {
+    return new Date(unix_ts * 1e3).toISOString();
+}
+
 class DataSection extends Component {
     constructor(props) {
         super(props);
@@ -25,11 +30,15 @@ class DataSection extends Component {
         var mid = this.props.mid;
 
         if(mid) {
-            this.props.actions.makeQuery('/en/api/quicklook/' + mid + '/parameter/?points=100', {}, function(resp) {
+            this.props.actions.makeQuery('/en/api/download/' + mid + '/quicklook?source=parameter&points=100', {}, function(resp) {
                 this.setState(function() {
                     return {
-                        data: resp.data.mv,
-                        desc: resp.parameter.description
+                        main: resp.source.name,
+                        data: resp.data,
+                        desc: resp.source.description,
+                        time: resp.timelapse,
+                        ylab: resp.value.name,
+                        unit: resp.value.units
                     }
                 })
             }.bind(this))
@@ -73,10 +82,11 @@ class DataSection extends Component {
                 <Quicklook
                     data = {this.state.data}
                     title = {this.state.desc}
-                    xlabel = {this.props.xlabel}
-                    ylabel = {this.props.ylabel}
+                    timelapse = {UnixToISO(this.state.time.start) + " – " + UnixToISO(this.state.time.end)}
+                    ylabel = {this.state.ylab + " (" + this.state.unit + ")"}
                     onClose = {this.closeQuicklook}
                     show = {this.state.quicklookStatus}
+                    time = {this.state.time}
                 />
                 }
             </div>


### PR DESCRIPTION
Okay there is the Quicklook thing now, but I have 2 concerns:
- Please edit the modal title back if you think it should be done, but we need the timeline somewhere on the plot too I think.
- Searching for sessions requests all the quicklooks right away before the user presses the button. Is that intentional?