### PR TITLE
Time filter for data and quicklooks

### DIFF
--- a/backend/promis/backend_api/renderer.py
+++ b/backend/promis/backend_api/renderer.py
@@ -34,7 +34,7 @@ class TextRenderer(renderers.BaseRenderer):
 
 class AsciiRenderer(TextRenderer):
     media_type = 'text/plain'
-    format = 'ascii'
+    format = 'txt'
 
     def process(self, table, data):
         return export.ascii_export(table, data['value']['name'], data['value']['units'])

--- a/backend/promis/backend_api/serializer.py
+++ b/backend/promis/backend_api/serializer.py
@@ -123,7 +123,7 @@ class QuicklookSerializer(serializers.Serializer):
 
     def get_data(self, obj):
         doc_obj = obj.instance(self.source_name())
-        return doc_obj.quicklook(self.context['view'].points)
+        return doc_obj.quicklook(self.context['view'].points, doc_obj.timeslice(*self.context['view'].time_filter))
 
     def source_name(self):
         # TODO: swagger should do the default here
@@ -142,7 +142,7 @@ class JSONDataSerializer(QuicklookSerializer):
 
     def get_data(self, obj):
         doc_obj = obj.instance(self.source_name())
-        return doc_obj.data()
+        return doc_obj.data(doc_obj.timeslice(*self.context['view'].time_filter))
 
 
 class MeasurementsSerializer(serializers.ModelSerializer):

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -154,6 +154,12 @@ class DownloadView(viewsets.GenericViewSet):
     # TODO: when we fix swagger route generation this may be
     # turned redundant by just inheriting the mixin
     def create_data(self):
+        try:
+            self.time_filter = [ self.request.query_params.get(key, None) for key in [ 'time_begin', 'time_end' ] ]
+            self.time_filter = [ int(x) if x is not None else None for x in self.time_filter ]
+        except ValueError:
+            raise NotFound("Time filter is not a number")
+
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -179,14 +185,6 @@ class DownloadView(viewsets.GenericViewSet):
         if self.points <= 0:
             raise NotFound("Non-positive amount of points requested")
 
-        # TODO: STUB: determine upper cap, that depends on the type in question
-        # if self.points > max_points_for_this_json:
-        #   raise NotFound("Too much points requested")
-
-        # TODO: STUB: determine if user is not authenticated, lower the cap for them
-        # if user_not_authenticated and self.points > max_points_for_this_json * some_coeff:
-        #   raise NotAuthenticated
-
         self.serializer_class = serializer.QuicklookSerializer
         return self.create_data()
 
@@ -196,7 +194,6 @@ class DownloadView(viewsets.GenericViewSet):
                                       renderer.AsciiRenderer,
                                       renderer.CSVRenderer))
     def data(self, request, id):
-        self.points = 10
         self.serializer_class = serializer.JSONDataSerializer
         return self.create_data()
 

--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -155,10 +155,12 @@ class DownloadView(viewsets.GenericViewSet):
     # turned redundant by just inheriting the mixin
     def create_data(self):
         try:
-            self.time_filter = [ self.request.query_params.get(key, None) for key in [ 'time_begin', 'time_end' ] ]
+            self.time_filter = [ self.request.query_params.get(key, None) for key in [ 'time_start', 'time_end' ] ]
             self.time_filter = [ int(x) if x is not None else None for x in self.time_filter ]
         except ValueError:
             raise NotFound("Time filter is not a number")
+
+        # TODO: check that time_filter lies within the session's bounds
 
         instance = self.get_object()
         serializer = self.get_serializer(instance)

--- a/backend/promis/classes/base_data.py
+++ b/backend/promis/classes/base_data.py
@@ -20,20 +20,9 @@
 #
 '''Base functionality for object-oriented data model'''
 
+import unix_time
+
 class BaseData:
-    def __init__(self, doc, source, measurement):
-        self.doc = doc
-        self.source = source
-        self.measurement = measurement
-
-    def data_start(self):
-        return self.measurement.session.time_begin
-
-    def frequency(self):
-        return self.measurement.sampling_frequency
-
-
-class BaseTimeSeries(BaseData):
     '''
     Derived classes are expected to implement:
     - self.__len__          -- for sample size
@@ -41,28 +30,46 @@ class BaseTimeSeries(BaseData):
     - self.data_start       -- UNIX timestamp
     - self.frequency        -- sampling frequency
     '''
+    def __init__(self, doc, source, measurement):
+        self.doc = doc
+        self.source = source
+        self.measurement = measurement
+
+    def data_start(self):
+        return unix_time.datetime_to_utc(self.measurement.session.time_begin)
+
+    def frequency(self):
+        return self.measurement.sampling_frequency
 
     def timeslice(self, start, end):
         '''
-        Returns data between start and end inclusively.
+        Returns a slice for accessing data between start and end inclusively.
         start and end are UNIX seconds at UTC.
         '''
-        data_end = self.data_start + len(self) // self.frequency
-        if start < self.data_start or end > data_end:
+        data_end = self.data_start() + len(self) // self.frequency()
+
+        # Check for open bounds
+        if end is None:
+            end = data_end
+        if start is None:
+            start = self.data_start()
+
+        if start < self.data_start() or end > data_end:
             raise IndexError
 
         # Shifting the bounds
-        start -= self.data_start
-        end -= self.data_start
+        start -= self.data_start()
+        end -= self.data_start()
 
         # Converting time to samples
-        start *= self.frequency
-        end *= self.frequency
+        start *= self.frequency()
+        end *= self.frequency()
 
-        return self[start:end] # TODO yield?
+        return slice(int(start),int(end))
+
 
 # TODO: expand the scope to include multiple variables
-class SingleVarTimeSeries(BaseTimeSeries):
+class SingleVarTimeSeries(BaseData):
     '''
     [en]: Repeated measurement of a single variable
     [uk]: Періодичне вимірювання єдиної змінної
@@ -76,11 +83,11 @@ class SingleVarTimeSeries(BaseTimeSeries):
     def __getitem__(self, idx):
         return self.doc[idx]
 
-    def data(self):
-        return self.doc
+    def data(self, selection = slice(None)):
+        return self.doc[selection]
 
     # TODO: propagate upwards?
-    def quicklook(self, points):
+    def quicklook(self, points, selection = slice(None)):
         '''
         Generates a quicklook of the time series object sampled at
         given number of points.
@@ -116,4 +123,4 @@ class SingleVarTimeSeries(BaseTimeSeries):
         span = len(self) / points
 
         for i in range(points):
-            yield avg_float(self, int(span * i), span)
+            yield avg_float(self.data(selection), int(span * i), span)

--- a/backend/promis/classes/base_data.py
+++ b/backend/promis/classes/base_data.py
@@ -110,17 +110,25 @@ class SingleVarTimeSeries(BaseData):
             if ratio > 0.00001:
                 s += l[n + int(span)] * ratio
 
-                return s / span
+            return s / span
+
+        v = self.data(selection)
 
         # If given too much points, return the original data
         # TODO: make configurable somewhere
         # TODO: maybe depend on the user's level?
-        max_points = 0.3 * len(self)
+        max_points = int(0.3 * len(v))
         if points > max_points:
             points = max_points
 
+        # If the above gets us with zero, return None
+        # This makes sense as it prevents the user from loading
+        # all the data by querying 1 sec quicklooks
+        if points <= 0:
+            return
+
         # Determining how many points are averaged
-        span = len(self) / points
+        span = len(v) / points
 
         for i in range(points):
-            yield avg_float(self.data(selection), int(span * i), span)
+            yield avg_float(v, int(span * i), span)


### PR DESCRIPTION
- Both data and quicklooks accept `time_start` and `time_end` arguments that determine the start and the end of the selection in UNIX section;
- The underlying object data model is now sliceable and has a `timeslice(start, end)` method which generates a `slice` object for accessing data between `start` and `end` in UNIX seconds;
- Both data and orbit points will be trimmed according to the selection;
- Quicklooks don't allow for resolution of more than 30% of the available data (currently non-configurable), thus asking for 3 sec interval on 1 Hz will give zero data points. This is to prevent the user from successively querying 1 sec intervals and getting all the data through quicklooks;
- `txt` and `csv` formats now make the browser save the data to a file, filename is provisionally set to `<start>_<end>_<value_short_name>.<format>`.

TODO in further pulls: 
- restore persmissions
- play around with out of range values