### PR TITLE
Project filter for Parameters/Channels

### DIFF
--- a/backend/promis/backend_api/views.py
+++ b/backend/promis/backend_api/views.py
@@ -42,10 +42,6 @@ class PromisViewSet(viewsets.ReadOnlyModelViewSet):
 class SessionFilter(django_filters.rest_framework.FilterSet):
     time_begin = django_filters.NumberFilter(method='unix_time_filter')
     time_end = django_filters.NumberFilter(method='unix_time_filter')
-    project = django_filters.ModelChoiceFilter(name='space_project',
-                                               queryset = models.Space_project.objects.all())
-    satellite = django_filters.ModelChoiceFilter(name='space_project',
-                                                 queryset = models.Space_project.objects.all())
 
     # TODO: make a separate class?
     def unix_time_filter(self, queryset, name, value):
@@ -56,13 +52,13 @@ class SessionFilter(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = models.Session
-        fields = ['space_project', 'time_begin', 'time_end', 'project', 'satellite']
+        fields = ( 'space_project', 'time_begin', 'time_end' )
 
 class MeasurementsFilter(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = models.Measurement
-        fields = ['session', 'parameter']
+        fields = ( 'session', 'parameter' )
 
 class ProjectsView(PromisViewSet):
     queryset = models.Space_project.objects.all()
@@ -71,11 +67,12 @@ class ProjectsView(PromisViewSet):
 class ChannelsView(PromisViewSet):
     queryset = models.Channel.objects.all()
     serializer_class = serializer.ChannelsSerializer
+    filter_fields = ( 'device__space_project', )
 
 class ParametersView(PromisViewSet):
     queryset = models.Parameter.objects.all()
     serializer_class = serializer.ParametersSerializer
-    filter_fields = ('channel',)
+    filter_fields = ( 'channel', 'channel__device__space_project', )
 
 class DevicesView(PromisViewSet):
     queryset = models.Device.objects.all()

--- a/doc/promis_api.yaml
+++ b/doc/promis_api.yaml
@@ -84,7 +84,7 @@ paths:
         The Sattelite Devices endpoint returns a list of available devices
         installed on the specific satellite (used in particular space project).
       parameters:
-        - name: project
+        - name: space_project
           in: query
           description: Project ID to query its satellite devices for
           type: integer
@@ -142,6 +142,10 @@ paths:
         - name: project
           in: query
           description: Project ID to query its satellite channels for
+          type: integer
+        - name: space_project
+          in: query
+          description: Project ID to query its satellite devices for
           type: integer
       responses:
         200:
@@ -337,11 +341,17 @@ paths:
         Get list of parameters
       parameters:
         - name: channel
+          required: false
           description: Desired channel ID(s)
           type: array
           in: query
           items:
             type: integer
+        - name: space_project
+          in: query
+          description: Project ID to query its satellite devices for
+          type: integer
+        # TODO: not implemented
         - name: minfreq
           type: integer
           in: query


### PR DESCRIPTION
Pass `space_project` in the query. Parameters view still needs a `channel` parameter due to swagger bug labeling it as required. Also removed reduntant filters from the Sessions view so it's `space_project` all over now. Rationale: less UI confusion. 
