### PR TITLE
Update npm

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,10 @@ RUN mkdir -p /usr/src/promis/app
 WORKDIR /usr/src/promis
 ADD package.json /usr/src/promis/
 
+# Update npm
+# https://github.com/npm/npm/issues/9863
+RUN cd $(npm root -g)/npm     && npm install -g fs-extra     && sed -i -e s/graceful-fs/fs-extra/ -e s/fs.rename/fs.move/ ./lib/utils/rename.js     && npm install -g npm@^6.0.0
+
 # Install packages needed
 RUN npm install
 ADD webpack.config.js /usr/src/promis/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ ADD package.json /usr/src/promis/
 
 # Update npm
 # https://github.com/npm/npm/issues/9863
-RUN cd $(npm root -g)/npm     && npm install -g fs-extra     && sed -i -e s/graceful-fs/fs-extra/ -e s/fs.rename/fs.move/ ./lib/utils/rename.js     && npm install -g npm@^6.0.0
+RUN cd $(npm root -g)/npm     && npm install -g fs-extra     && sed -i -e s/graceful-fs/fs-extra/ -e s/fs.rename/fs.move/ ./lib/utils/rename.js     && npm install -g npm@^5.0.0
 
 # Install packages needed
 RUN npm install


### PR DESCRIPTION
Some of the frontend deps seem not to have their version frozen, and our older NPM fails.

Ideally we'd bump both nodejs and npm version at the base container, but this ideally requires communicating with upstream, or we could just fork if they are irresponsive.

The PR provides a quick way to update NPM to a newer version during our build. 

Notes:
1. Version 5 npm, because 6+ runs into zlib problems on our older nodejs and the only good advice online is "update your node".
2. The black magic is there to alter the logic for some of the package updates evading filesystem operations that don't work cross-filesystem, such as hard linking I assume, since we use Docker and each build stage has its own fs.